### PR TITLE
Dt 461 skeleton test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,13 +58,12 @@ executors:
         environment:
           - SERVICES=sqs
           - DEBUG=${DEBUG- }
-          - DATA_DIR=${DATA_DIR- }
-          - PORT_WEB_UI=${PORT_WEB_UI- }
-          - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-          - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+          - DATA_DIR=/tmp/localstack/data
           - DOCKER_HOST=unix:///var/run/docker.sock
+          - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
           - AWS_EXECUTION_ENV=True
           - DEFAULT_REGION=eu-west-2
+          - TMPDIR=/private
     working_directory: ~/app
 
 orbs:
@@ -83,7 +82,9 @@ jobs:
             - gradle-{{ checksum "build.gradle" }}
             - gradle-
       - run:
-          command: REMOTE_LOCALSTACK=true ./gradlew build
+          environment:
+            SQS_PROVIDER: localstack
+          command: ./gradlew build
       - run:
           name: Record the Application Version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,16 @@ jobs:
     executor: builder
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle" }}
             - gradle-
-      - run: ./gradlew build
+      - run:
+          environment:
+            TESTCONTAINERS_RYUK_DISABLED: false
+          command: ./gradlew build
       - run:
           name: Record the Application Version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,17 @@ executors:
   builder:
     docker:
       - image: circleci/openjdk:11-jdk
+      - image: localstack/localstack:0.10.5
+        environment:
+          - SERVICES=sqs
+          - DEBUG=${DEBUG- }
+          - DATA_DIR=${DATA_DIR- }
+          - PORT_WEB_UI=${PORT_WEB_UI- }
+          - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+          - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+          - DOCKER_HOST=unix:///var/run/docker.sock
+          - AWS_EXECUTION_ENV=True
+          - DEFAULT_REGION=eu-west-2
     working_directory: ~/app
 
 orbs:
@@ -67,16 +78,12 @@ jobs:
     executor: builder
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle" }}
             - gradle-
       - run:
-          environment:
-            TESTCONTAINERS_RYUK_DISABLED: false
-          command: ./gradlew build
+          command: REMOTE_LOCALSTACK=true ./gradlew build
       - run:
           name: Record the Application Version
           command: |

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,8 @@ dependencies {
   testImplementation 'com.github.tomakehurst:wiremock-standalone:2.25.1'
   testImplementation 'net.javacrumbs.json-unit:json-unit-assertj:2.11.1'
   testImplementation 'com.nhaarman:mockito-kotlin-kt1.1:1.6.0'
+  testImplementation "org.testcontainers:localstack:1.11.4"
+  testImplementation "org.awaitility:awaitility-kotlin:4.0.2"
 }
 
 task copyAgent(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -137,3 +137,4 @@ task copyAgent(type: Copy) {
 }
 
 assemble.dependsOn copyAgent
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusher.kt
@@ -18,15 +18,15 @@ open class PrisonerMovementListenerPusher(private val offenderService: OffenderS
 
   @JmsListener(destination = "\${sqs.queue.name}")
   open fun pushPrisonMovementToProbation(requestJson: String?) {
-    val (Message, MessageId) = gson.fromJson<Message>(requestJson, Message::class.java)
-    val (bookingId, eventType) = gson.fromJson(Message, PrisonMovementMessage::class.java)
-
-    log.info("Received message {} type {} for booking {}", MessageId, eventType, bookingId)
     log.debug(requestJson)
-    // call offender service
-    // call community service
+    val (Message, MessageId, MessageAttributes) = gson.fromJson<Message>(requestJson, Message::class.java)
+    val (bookingId, movementSeq) = gson.fromJson(Message, ExternalPrisonerMovementMessage::class.java)
+
+    log.info("Received message $MessageId type ${MessageAttributes.eventType?.Value} for booking $bookingId with sequence $movementSeq")
   }
 }
 
-data class Message(val Message: String, val MessageId: String)
-data class PrisonMovementMessage(val bookingId: Long, val eventType: String)
+data class EventType(val Value: String)
+data class MessageAttributes(val eventType: EventType?)
+data class Message(val Message: String, val MessageId: String, val MessageAttributes: MessageAttributes)
+data class ExternalPrisonerMovementMessage(val bookingId: Long, val movementSeq: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusher.kt
@@ -19,14 +19,14 @@ open class PrisonerMovementListenerPusher(private val offenderService: OffenderS
   @JmsListener(destination = "\${sqs.queue.name}")
   open fun pushPrisonMovementToProbation(requestJson: String?) {
     log.debug(requestJson)
-    val (Message, MessageId, MessageAttributes) = gson.fromJson<Message>(requestJson, Message::class.java)
-    val (bookingId, movementSeq) = gson.fromJson(Message, ExternalPrisonerMovementMessage::class.java)
+    val (message, messageId, messageAttributes) = gson.fromJson<Message>(requestJson, Message::class.java)
+    val (bookingId, movementSeq) = gson.fromJson(message, ExternalPrisonerMovementMessage::class.java)
 
-    log.info("Received message $MessageId type ${MessageAttributes.eventType?.Value} for booking $bookingId with sequence $movementSeq")
+    log.info("Received message $messageId type ${messageAttributes.eventType.Value} for booking $bookingId with sequence $movementSeq")
   }
 }
 
 data class EventType(val Value: String)
-data class MessageAttributes(val eventType: EventType?)
+data class MessageAttributes(val eventType: EventType)
 data class Message(val Message: String, val MessageId: String, val MessageAttributes: MessageAttributes)
 data class ExternalPrisonerMovementMessage(val bookingId: Long, val movementSeq: Long)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
@@ -13,27 +13,27 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles("test,test-queue")
 @RunWith(SpringJUnit4ClassRunner::class)
 class PrisonerMovementIntegrationTest {
 
     @Autowired
-    private val sqsClient: AmazonSQS? = null
+    private lateinit var sqsClient: AmazonSQS
 
     @Autowired
-    private val queueUrl: String? = null
+    private lateinit var queueUrl: String
 
     @Test
     fun `will consume a prison movement message`() {
         val message = this::class.java.getResource("/messages/externalMovement.json").readText()
 
-        sqsClient!!.sendMessage(queueUrl, message)
+        sqsClient.sendMessage(queueUrl, message)
 
-        await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { count -> count == 0 }
+        await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
     }
 
     private fun getNumberOfMessagesCurrentlyOnQueue(): Int? {
-        val queueAttributes = sqsClient!!.getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
+        val queueAttributes = sqsClient.getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
         return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
@@ -7,18 +7,16 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("integration-message-test", "test")
+@ActiveProfiles("test")
 @RunWith(SpringJUnit4ClassRunner::class)
 class PrisonerMovementIntegrationTest {
 
-    @Qualifier("awsLocalTestClient")
     @Autowired
     private val sqsClient: AmazonSQS? = null
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/PrisonerMovementIntegrationTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.prisontoprobation
+
+import com.amazonaws.services.sqs.AmazonSQS
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration-message-test", "test")
+@RunWith(SpringJUnit4ClassRunner::class)
+class PrisonerMovementIntegrationTest {
+
+    @Qualifier("awsLocalTestClient")
+    @Autowired
+    private val sqsClient: AmazonSQS? = null
+
+    @Autowired
+    private val queueUrl: String? = null
+
+    @Test
+    fun `will consume a prison movement message`() {
+        val message = this::class.java.getResource("/messages/externalMovement.json").readText()
+
+        sqsClient!!.sendMessage(queueUrl, message)
+
+        await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { count -> count == 0 }
+    }
+
+    private fun getNumberOfMessagesCurrentlyOnQueue(): Int? {
+        val queueAttributes = sqsClient!!.getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
+        return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
+    }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
@@ -5,11 +5,13 @@ import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.testcontainers.containers.localstack.LocalStackContainer
 
 
 @Configuration
 @ConditionalOnProperty(name = ["sqs.provider"], havingValue = "embedded-localstack")
+@Profile("test-queue")
 open class JmsLocalStackConfig(private val localStackContainer: LocalStackContainer) {
 
   @Bean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
@@ -5,16 +5,14 @@ import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.testcontainers.containers.localstack.LocalStackContainer
 
 
 @Configuration
-@Profile("integration-message-test")
+@ConditionalOnProperty(name = ["sqs.provider"], havingValue = "embedded-localstack")
 open class JmsLocalStackConfig(private val localStackContainer: LocalStackContainer) {
 
   @Bean
-  @ConditionalOnProperty(name = ["sqs.provider"], havingValue = "test-localstack")
   open fun awsLocalTestClient(): AmazonSQS {
     return AmazonSQSClientBuilder.standard()
             .withEndpointConfiguration(localStackContainer.getEndpointConfiguration(LocalStackContainer.Service.SQS))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/JmsLocalStackConfig.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.prisontoprobation.config
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.testcontainers.containers.localstack.LocalStackContainer
+
+
+@Configuration
+@Profile("integration-message-test")
+open class JmsLocalStackConfig(private val localStackContainer: LocalStackContainer) {
+
+  @Bean
+  @ConditionalOnProperty(name = ["sqs.provider"], havingValue = "test-localstack")
+  open fun awsLocalTestClient(): AmazonSQS {
+    return AmazonSQSClientBuilder.standard()
+            .withEndpointConfiguration(localStackContainer.getEndpointConfiguration(LocalStackContainer.Service.SQS))
+            .build()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.prisontoprobation.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.testcontainers.containers.localstack.LocalStackContainer
+
+@Configuration
+@Profile("integration-message-test")
+open class LocalStackConfig {
+  private val localStackContainer: LocalStackContainer = LocalStackContainer()
+          .withServices(LocalStackContainer.Service.SQS)
+          .withEnv("HOSTNAME_EXTERNAL", "localhost")
+
+  @Bean
+  open fun localStackContainer(): LocalStackContainer {
+    localStackContainer.start()
+    return localStackContainer
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
@@ -1,20 +1,29 @@
 package uk.gov.justice.digital.hmpps.prisontoprobation.config
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.testcontainers.containers.localstack.LocalStackContainer
 
 @Configuration
-@Profile("integration-message-test")
+@ConditionalOnProperty(name = ["sqs.provider"], havingValue = "embedded-localstack")
 open class LocalStackConfig {
-  private val localStackContainer: LocalStackContainer = LocalStackContainer()
-          .withServices(LocalStackContainer.Service.SQS)
-          .withEnv("HOSTNAME_EXTERNAL", "localhost")
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
 
   @Bean
   open fun localStackContainer(): LocalStackContainer {
+    log.info("Starting localstack...")
+    val localStackContainer: LocalStackContainer = LocalStackContainer()
+            .withServices(LocalStackContainer.Service.SQS)
+            .withEnv("HOSTNAME_EXTERNAL", "localhost")
+
     localStackContainer.start()
+    log.info("Started localstack.")
     return localStackContainer
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalStackConfig.kt
@@ -5,10 +5,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.testcontainers.containers.localstack.LocalStackContainer
 
 @Configuration
 @ConditionalOnProperty(name = ["sqs.provider"], havingValue = "embedded-localstack")
+@Profile("test-queue")
 open class LocalStackConfig {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
@@ -1,22 +1,19 @@
 package uk.gov.justice.digital.hmpps.prisontoprobation.config
 
 import com.amazonaws.services.sqs.AmazonSQS
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 
 @Configuration
-@Profile("integration-message-test")
-open class TestQueueConfig(@Qualifier("awsLocalTestClient")
-                           private val sqsClient: AmazonSQS,
+open class TestQueueConfig(
+                           private val sqsClient: AmazonSQS?,
                            @Value("\${sqs.queue.name}")
                            private val queueName: String) {
     @Bean
-    open fun queueUrl(): String {
-        sqsClient.createQueue(queueName)
-        return sqsClient.getQueueUrl(queueName)!!.queueUrl
+    open fun queueUrl(): String? {
+        sqsClient?.createQueue(queueName)
+        return sqsClient?.getQueueUrl(queueName)?.queueUrl
     }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
@@ -3,17 +3,20 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.config
 import com.amazonaws.services.sqs.AmazonSQS
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
+@Profile("test-queue")
 open class TestQueueConfig(
-                           private val sqsClient: AmazonSQS?,
+                           private val sqsClient: AmazonSQS,
                            @Value("\${sqs.queue.name}")
                            private val queueName: String) {
     @Bean
-    open fun queueUrl(): String? {
-        sqsClient?.createQueue(queueName)
-        return sqsClient?.getQueueUrl(queueName)?.queueUrl
+    open fun queueUrl(): String {
+        sqsClient.createQueue(queueName)
+        return sqsClient.getQueueUrl(queueName).queueUrl
     }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/TestQueueConfig.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.prisontoprobation.config
+
+import com.amazonaws.services.sqs.AmazonSQS
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("integration-message-test")
+open class TestQueueConfig(@Qualifier("awsLocalTestClient")
+                           private val sqsClient: AmazonSQS,
+                           @Value("\${sqs.queue.name}")
+                           private val queueName: String) {
+    @Bean
+    open fun queueUrl(): String {
+        sqsClient.createQueue(queueName)
+        return sqsClient.getQueueUrl(queueName)!!.queueUrl
+    }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerMovementListenerPusherTest.kt
@@ -13,17 +13,6 @@ class PrisonerMovementListenerPusherTest {
 
   private lateinit var listener: PrisonerMovementListenerPusher
 
-  private val validPrisonMovement = """{
-    "MessageId": "ae06c49e-1f41-4b9f-b2f2-dcca610d02cd", "Type": "Notification", "Timestamp": "2019-10-21T14:01:18.500Z", 
-    "Message": 
-      "{\"offenderId\":\"AB123D\"}", 
-    "TopicArn": "arn:aws:sns:eu-west-1:000000000000:offender_events", 
-    "MessageAttributes": {"eventType": {"Type": "String", "Value": "KA-KE"}, 
-    "id": {"Type": "String", "Value": "8b07cbd9-0820-0a0f-c32f-a9429b618e0b"}, 
-    "contentType": {"Type": "String", "Value": "text/plain;charset=UTF-8"}, 
-    "timestamp": {"Type": "Number.java.lang.Long", "Value": "1571666478344"}}}""".trimIndent()
-
-
   @Before
   fun before() {
     listener = PrisonerMovementListenerPusher(offenderService, communityService)
@@ -31,7 +20,9 @@ class PrisonerMovementListenerPusherTest {
 
   @Test
   fun `does nothing`() {
-    listener.pushPrisonMovementToProbation(validPrisonMovement)
+    val message = this::class.java.getResource("/messages/externalMovement.json").readText()
+
+    listener.pushPrisonMovementToProbation(message)
   }
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,7 +2,8 @@ graceful:
   shutdown.enabled: false
 
 sqs:
-  provider: test-localstack
+  provider: embedded-localstack
+  endpoint.url: http://localhost:4576
 
 prisontoprobation:
   client:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,9 @@
 graceful:
   shutdown.enabled: false
 
+sqs:
+  provider: test-localstack
+
 prisontoprobation:
   client:
     client-id: prisontoprobation-api-client
@@ -14,7 +17,6 @@ oauth:
   endpoint.url: http://localhost:8090/auth
 
 community:
-  enabled: true
   endpoint.url: http://localhost:8096
 
 management.endpoint:

--- a/src/test/resources/messages/externalMovement.json
+++ b/src/test/resources/messages/externalMovement.json
@@ -1,0 +1,29 @@
+{
+  "Type": "Notification",
+  "MessageId": "b18d62f0-3059-5c2c-af05-346667bd4a28",
+  "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
+  "Message": "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":1200835,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}",
+  "Timestamp": "2020-01-13T11:33:56.874Z",
+  "SignatureVersion": "1",
+  "Signature": "Qo6lSZTKmjjNKUGewr5WK022bnhcB1756qHjcy91lUyZXW8yHPCUYzy9nZubLg9evh8bdZ9RZiGx6Ast2wcL0FUyP2rMHO7cKCF4tVXq0QeYyRfMaDNNP/N8Zqg16oTlfu51ZOarygqQRNctAiL/Pz4qFc7x1HAf1InoJWD7Sy1IqC2TdpEHVGNtJggdMpLcVUkOKz0uciBT6QunGsYLjVlHT72TZImjff9iVRFKrODzcSZJk6do8ZX6smDZoOZEX8jfq7XcCt9chLcvXXdeF8p+8WTeZJATc2ZB3mK0j5WZgtdwXRh2MLHUku4mBmA8K4twf3vak8EXbw+oC02wIg==",
+  "SigningCertURL": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",
+  "UnsubscribeURL": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7:92545cfe-de5d-43e1-8339-c366bf0172aa",
+  "MessageAttributes": {
+    "eventType": {
+      "Type": "String",
+      "Value": "EXTERNAL_MOVEMENT_RECORD-INSERTED"
+    },
+    "id": {
+      "Type": "String",
+      "Value": "d6801418-4208-3c8e-6b24-4c3e7e05f534"
+    },
+    "contentType": {
+      "Type": "String",
+      "Value": "text/plain;charset=UTF-8"
+    },
+    "timestamp": {
+      "Type": "Number.java.lang.Long",
+      "Value": "1578915236869"
+    }
+  }
+}


### PR DESCRIPTION
- Added integration test using localstack
- Running locally be default will use org.testcontainers:localstack (which itself uses Docker to run localstack in the background)
- In Circle we have to fall-back to running localstack manually since the only supported way of running org.testcontainers is via i Circle js a VM rather Docker; i.e no local docker in docker support, only remote docker support in Circle
