### PR TITLE
DT-463 Call community-api to fake update custody record in Delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
@@ -12,23 +12,23 @@ import org.springframework.web.client.RestTemplate
 
 @Service
 open class CommunityService(@Qualifier("communityApiRestTemplate") private val restTemplate: RestTemplate) {
-  companion object {
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
-  }
-
-  open fun updateProbationCustody(offenderNo: String, bookingNo: String, updateCustody: UpdateCustody): Custody? {
-    try {
-      val response = restTemplate.exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, offenderNo, bookingNo)
-      return response.body!!
-    } catch (e : HttpClientErrorException) {
-      if (e.statusCode != HttpStatus.NOT_FOUND) throw e
-      log.info("Booking {} not found for {} message is {}", bookingNo, offenderNo, e.responseBodyAsString)
-      return null
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
-  }
+
+    open fun updateProbationCustody(offenderNo: String, bookingNo: String, updateCustody: UpdateCustody): Custody? {
+      return try {
+          val response = restTemplate.exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, offenderNo, bookingNo)
+        response.body!!
+      } catch (e: HttpClientErrorException) {
+          if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+          log.info("Booking {} not found for {} message is {}", bookingNo, offenderNo, e.responseBodyAsString)
+        null
+      }
+    }
 }
 
-data class UpdateCustody (
+data class UpdateCustody(
         val nomsPrisonInstitutionCode: String
 )
 
@@ -36,6 +36,6 @@ data class Institution(
         val description: String?
 )
 
-data class Custody (
+data class Custody(
         val institution: Institution
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
@@ -3,7 +3,11 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.services
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 
 @Service
@@ -12,10 +16,26 @@ open class CommunityService(@Qualifier("communityApiRestTemplate") private val r
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  open fun updateProbationCustody(offender: Offender) {
+  open fun updateProbationCustody(offenderNo: String, bookingNo: String, updateCustody: UpdateCustody): Custody? {
+    try {
+      val response = restTemplate.exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, offenderNo, bookingNo)
+      return response.body!!
+    } catch (e : HttpClientErrorException) {
+      if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+      log.info("Booking {} not found for {} message is {}", bookingNo, offenderNo, e.responseBodyAsString)
+      return null
+    }
   }
 }
 
-data class Offender (
-  val offenderNo: String
+data class UpdateCustody (
+        val nomsPrisonInstitutionCode: String
+)
+
+data class Institution(
+        val description: String?
+)
+
+data class Custody (
+        val institution: Institution
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityService.kt
@@ -17,14 +17,14 @@ open class CommunityService(@Qualifier("communityApiRestTemplate") private val r
     }
 
     open fun updateProbationCustody(offenderNo: String, bookingNo: String, updateCustody: UpdateCustody): Custody? {
-      return try {
-          val response = restTemplate.exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, offenderNo, bookingNo)
-        response.body!!
-      } catch (e: HttpClientErrorException) {
-          if (e.statusCode != HttpStatus.NOT_FOUND) throw e
-          log.info("Booking {} not found for {} message is {}", bookingNo, offenderNo, e.responseBodyAsString)
-        null
-      }
+        return try {
+            val response = restTemplate.exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, offenderNo, bookingNo)
+            response.body!!
+        } catch (e: HttpClientErrorException) {
+            if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+            log.info("Booking {} not found for {} message is {}", bookingNo, offenderNo, e.responseBodyAsString)
+            null
+        }
     }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderService.kt
@@ -28,13 +28,13 @@ open class OffenderService(@Qualifier("elite2ApiRestTemplate") val restTemplate:
     }
 
     open fun getMovement(bookingId: Long, movementSeq: Long): Movement? {
-        try {
+        return try {
             val response = restTemplate.getForEntity("/api/bookings/{bookingId}/movement/{movementSeq}", Movement::class.java, bookingId, movementSeq)
-            return response.body!!
+            response.body!!
         } catch (e : HttpClientErrorException) {
             if (e.statusCode != HttpStatus.NOT_FOUND) throw e
             // 404 is "valid" since it means movement is for an inactive booking
-            return null
+            null
         }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderService.kt
@@ -5,8 +5,10 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.services
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDateTime
 
 @Service
@@ -20,9 +22,20 @@ open class OffenderService(@Qualifier("elite2ApiRestTemplate") val restTemplate:
         return response.body!![0]
     }
 
-    open fun getMovement(bookingId: Long, movementSeq: Long): Movement {
-        val response = restTemplate.getForEntity("/api/bookings/{bookingId}/movement/{movementSeq}", Movement::class.java, bookingId, movementSeq)
+    open fun getBooking(bookingId: Long): Booking {
+        val response = restTemplate.getForEntity("/api/bookings/{bookingId}?basicInfo=true", Booking::class.java, bookingId)
         return response.body!!
+    }
+
+    open fun getMovement(bookingId: Long, movementSeq: Long): Movement? {
+        try {
+            val response = restTemplate.getForEntity("/api/bookings/{bookingId}/movement/{movementSeq}", Movement::class.java, bookingId, movementSeq)
+            return response.body!!
+        } catch (e : HttpClientErrorException) {
+            if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+            // 404 is "valid" since it means movement is for an inactive booking
+            return null
+        }
     }
 }
 
@@ -46,8 +59,13 @@ data class Prisoner(
 data class Movement(
         val offenderNo: String,
         val createDateTime: LocalDateTime,
-        val fromAgency: String?,
-        val toAgency: String?,
+        val fromAgency: String,
+        val toAgency: String,
         val movementType: String,
         val directionCode: String
+)
+
+data class Booking(
+        val bookingNo: String,
+        val activeFlag: Boolean
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityServiceTest.kt
@@ -2,12 +2,21 @@
 
 package uk.gov.justice.digital.hmpps.prisontoprobation.services
 
-import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.junit.MockitoJUnitRunner
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import org.springframework.web.client.HttpClientErrorException
 
 @RunWith(MockitoJUnitRunner::class)
 class CommunityServiceTest {
@@ -20,14 +29,42 @@ class CommunityServiceTest {
     service = CommunityService(restTemplate)
   }
 
+
   @Test
-  fun `test update probation custody does diddly squat`() {
-    val offender = createOffender()
+  fun `test put custody calls rest template`() {
+    val expectedUpdatedCustody = createUpdatedCustody()
+    whenever(restTemplate.exchange(anyString(), any(), any(), eq(Custody::class.java), anyString(), anyString())).thenReturn(ResponseEntity.ok(expectedUpdatedCustody))
 
-    service.updateProbationCustody(offender)
+    val updateCustody = createUpdateCustody()
+    val updatedCustody = service.updateProbationCustody("AB123D", "38353A", updateCustody)
 
+    assertThat(updatedCustody).isEqualTo(expectedUpdatedCustody)
+
+    verify(restTemplate).exchange("/secure/offenders/nomsNumber/{nomsNumber}/custody/bookingNumber/{bookingNumber}", HttpMethod.PUT, HttpEntity(updateCustody), Custody::class.java, "AB123D", "38353A")
   }
 
-  private fun createOffender() = Offender(
-          offenderNo = "AB123D")
+  @Test
+  fun `test get movement will be null if not found`() {
+    whenever(restTemplate.exchange(anyString(), any(), any(), eq(Custody::class.java), anyString(), anyString())).thenThrow(HttpClientErrorException(HttpStatus.NOT_FOUND))
+
+    val updatedCustody = service.updateProbationCustody("AB123D", "38353A", createUpdateCustody())
+
+    assertThat(updatedCustody).isNull()
+  }
+
+  @Test
+  fun `test get movement will throw exception for other types of http responses`() {
+    whenever(restTemplate.exchange(anyString(), any(), any(), eq(Custody::class.java), anyString(), anyString())).thenThrow(HttpClientErrorException(HttpStatus.BAD_REQUEST))
+
+    assertThatThrownBy { service.updateProbationCustody("AB123D", "38353A", createUpdateCustody()) }.isInstanceOf(HttpClientErrorException::class.java)
+  }
+
+
+  private fun createUpdatedCustody() = Custody(
+          institution = Institution("Doncaster")
+  )
+
+  private fun createUpdateCustody(nomsPrisonInstitutionCode: String = "MDI") = UpdateCustody(
+          nomsPrisonInstitutionCode = nomsPrisonInstitutionCode
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderServiceTest.kt
@@ -4,14 +4,17 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.services
 
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import org.springframework.web.client.HttpClientErrorException
 import java.time.LocalDateTime
 
 class OffenderServiceTest {
@@ -51,6 +54,34 @@ class OffenderServiceTest {
         verify(restTemplate).getForEntity("/api/bookings/{bookingId}/movement/{movementSeq}", Movement::class.java, 1234L, 1L)
     }
 
+    @Test
+    fun `test get movement will be null if not found`() {
+        whenever(restTemplate.getForEntity<Movement>(anyString(), any(), anyLong(), anyLong())).thenThrow(HttpClientErrorException(HttpStatus.NOT_FOUND))
+
+        val movement = service.getMovement(1234L, 1L)
+
+        assertThat(movement).isNull()
+    }
+
+    @Test
+    fun `test get movement will throw exception for other types of http responses`() {
+        whenever(restTemplate.getForEntity<Movement>(anyString(), any(), anyLong(), anyLong())).thenThrow(HttpClientErrorException(HttpStatus.BAD_REQUEST))
+
+        assertThatThrownBy {  service.getMovement(1234L, 1L) } .isInstanceOf(HttpClientErrorException::class.java)
+    }
+
+    @Test
+    fun `test get booking calls rest template`() {
+        val expectedBooking = createBooking()
+        whenever(restTemplate.getForEntity<Booking>(anyString(), any(), anyLong())).thenReturn(ResponseEntity.ok(expectedBooking))
+
+        val booking = service.getBooking(1234L)
+
+        assertThat(booking).isEqualTo(expectedBooking)
+
+        verify(restTemplate).getForEntity("/api/bookings/{bookingId}?basicInfo=true", Booking::class.java, 1234L)
+    }
+
     private fun createPrisoner() = Prisoner(
             offenderNo = "AB123D",
             pncNumber = "",
@@ -74,5 +105,10 @@ class OffenderServiceTest {
             toAgency = "MDI",
             movementType = "TRN",
             directionCode = "OUT"
+    )
+
+    private fun createBooking() = Booking(
+            bookingNo = "38353A",
+            activeFlag = true
     )
 }

--- a/src/test/resources/mappings/getBooking_1200835.json
+++ b/src/test/resources/mappings/getBooking_1200835.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/bookings/1200835"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody":
+    {
+      "bookingId": 1200835,
+      "bookingNo": "38339A",
+      "offenderNo": "A5089DY",
+      "firstName": "ANDY",
+      "lastName": "MARKE",
+      "agencyId": "MDI",
+      "assignedLivingUnitId": 25638,
+      "activeFlag": true,
+      "dateOfBirth": "1970-01-01"
+    }
+  }
+}

--- a/src/test/resources/mappings/putCustody_A5089DY_38339A.json
+++ b/src/test/resources/mappings/putCustody_A5089DY_38339A.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPath": "/secure/offenders/nomsNumber/A5089DY/custody/bookingNumber/38339A"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody":
+    {
+      "bookingNumber": "38353A",
+      "institution": {
+        "institutionId": 157,
+        "isEstablishment": true,
+        "code": "UNKNOW",
+        "description": "Unknown",
+        "institutionName": "Unknown",
+        "establishmentType": {
+          "code": "E",
+          "description": "Prison"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- added call to actually update Delius (though that service is also still a dummy service that just logs what it would do rather than actually doing it)
- additional checks on movements associated with bookings that are no longer current (we see a handful of these being done by mistake)