### PR TITLE
DT-644 Check Delius sentence date prior to matching (and more telemetry events)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/ImprisonmentStatusChangeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/ImprisonmentStatusChangeService.kt
@@ -39,7 +39,7 @@ class ImprisonmentStatusChangeService(
     val (bookingId) = getSignificantStatusChange(message).onIgnore { return it.reason }
     val sentenceStartDate = getSentenceStartDate(bookingId).onIgnore { return it.reason }
     val booking = getActiveBooking(bookingId).onIgnore { return it.reason }
-    val offenderNo = offenderProbationMatchService.ensureOffenderNumberExistsInProbation(booking).onIgnore { return it.reason }
+    val offenderNo = offenderProbationMatchService.ensureOffenderNumberExistsInProbation(booking, sentenceStartDate).onIgnore { return it.reason }
     val (bookingNumber, _, _) = getBookingForInterestedPrison(booking).onIgnore { return it.reason.with(booking).with(sentenceStartDate) }
 
     return communityService.updateProbationCustodyBookingNumber(offenderNo, UpdateCustodyBookingNumber(sentenceStartDate, bookingNumber))?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
@@ -5,19 +5,22 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.Result.Success
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit.DAYS
 
 
 @Service
 class OffenderProbationMatchService(
     private val telemetryClient: TelemetryClient,
     private val offenderSearchService: OffenderSearchService,
-    private val offenderService: OffenderService
+    private val offenderService: OffenderService,
+    private val communityService: CommunityService
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun ensureOffenderNumberExistsInProbation(booking: Booking): Result<String, TelemetryEvent> {
+  fun ensureOffenderNumberExistsInProbation(booking: Booking, sentenceStartDate: LocalDate): Result<String, TelemetryEvent> {
     val prisoner = offenderService.getOffender(booking.offenderNo)
 
     val result = offenderSearchService.matchProbationOffender(MatchRequest(
@@ -32,22 +35,101 @@ class OffenderProbationMatchService(
 
     log.debug("${booking.offenderNo} matched ${result.matches.size} offender(s)")
 
-    // TODO for now just log the match and throw results away
+    // filter by those with matching sentence
+    val filteredCRNs = offendersWithMatchingSentenceDates(result, sentenceStartDate)
+
     telemetryClient.trackEvent(
         "P2POffenderMatch",
         mapOf(
             "offenderNo" to booking.offenderNo,
             "bookingNumber" to booking.bookingNo,
+            "matchedBy" to result.matchedBy,
             "matches" to result.matches.size.toString(),
-            "crns" to result.matches.joinToString { it.offender.otherIds?.crn ?: "unknown" }
-
+            "filtered_matches" to filteredCRNs.size.toString(),
+            "crns" to result.CRNs(),
+            "filtered_crns" to filteredCRNs.sorted().joinToString()
         ),
         null
     )
+
+
+    // Now do search without NOMS number to see if we would have got a match, and if so was it was the same match
+    // this is only to build up some analysis to  test how effective the matching aalgorithmis
+    val sample = offenderSearchService.matchProbationOffender(MatchRequest(
+        firstName = booking.firstName,
+        surname = booking.lastName,
+        dateOfBirth = booking.dateOfBirth,
+        nomsNumber = "",
+        croNumber = prisoner.croNumber,
+        pncNumber = prisoner.pncNumber,
+        activeSentence = true
+    ))
+
+    // filter by those with matching sentence
+    val sampleFilteredCRNs = offendersWithMatchingSentenceDates(sample, sentenceStartDate)
+
+
+    if (sampleFilteredCRNs == filteredCRNs) {
+      telemetryClient.trackEvent(
+          "P2POffenderPerfectMatch",
+          mapOf(
+              "offenderNo" to booking.offenderNo,
+              "bookingNumber" to booking.bookingNo,
+              "matchedBy" to sample.matchedBy,
+              "matches" to sample.matches.size.toString(),
+              "filtered_matches" to sampleFilteredCRNs.size.toString(),
+              "crns" to sample.CRNs(),
+              "filtered_crns" to filteredCRNs.sorted().joinToString()
+          ),
+          null
+      )
+    } else {
+      telemetryClient.trackEvent(
+          "P2POffenderImperfectMatch",
+          mapOf(
+              "offenderNo" to booking.offenderNo,
+              "bookingNumber" to booking.bookingNo,
+              "matches" to sample.matches.size.toString(),
+              "matchedBy" to sample.matchedBy,
+              "crns" to (sample.CRNList().intersect(result.CRNList())).joinToString(),
+              "extra_crns" to (sample.CRNList() - result.CRNList()).joinToString(),
+              "missing_crns" to (result.CRNList() - sample.CRNList()).joinToString(),
+              "extra_filtered_crns" to (sampleFilteredCRNs - filteredCRNs).joinToString(),
+              "missing_filtered_crns" to (filteredCRNs - sampleFilteredCRNs).joinToString()
+          ),
+          null
+      )
+    }
+
+    log.debug("${booking.offenderNo} matched ${result.matches.size} offender(s)")
 
     // TODO we are currently ignoring the response, but shortly we will return an error if we can't match with a
     // probation offender
     return Success(booking.offenderNo)
   }
 
+  private fun offendersWithMatchingSentenceDates(result: OffenderMatches, sentenceStartDate: LocalDate): Set<String> {
+    return result.matches
+        .map { it.offender.otherIds.crn }
+        .map { crn -> crn to custodySentenceDates(crn) }
+        .toMap()
+        .filter { (_, dates) -> dates.any { it.closeTo(sentenceStartDate) } }
+        .keys
+  }
+
+  private fun custodySentenceDates(crn: String): List<LocalDate> {
+    return communityService.getConvictions(crn).asSequence()
+        .filter { conviction -> conviction.active }
+        .map { conviction -> conviction.sentence }
+        .filterNotNull()
+        .filter { sentence -> sentence.custody?.let { true } ?: false }
+        .map { it.startDate }
+        .filterNotNull()
+        .toList()
+  }
 }
+
+private fun LocalDate.closeTo(date: LocalDate, days: Int = 7): Boolean = Math.abs(DAYS.between(this, date)) <= days
+
+private fun OffenderMatches.CRNs() = this.CRNList().joinToString()
+private fun OffenderMatches.CRNList() = this.matches.map { it.offender.otherIds.crn }.sorted()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderSearchService.kt
@@ -32,7 +32,8 @@ data class MatchRequest(
     )
 
 data class OffenderMatches(
-    val matches: List<OffenderMatch>
+    val matches: List<OffenderMatch>,
+    val matchedBy: String? = null
 )
 
 data class OffenderMatch(
@@ -40,6 +41,7 @@ data class OffenderMatch(
 )
 
 data class OffenderDetail(
+    val otherIds: IDs,
     val previousSurname: String? = null,
     val title: String? = null,
     val firstName: String? = null,
@@ -47,12 +49,11 @@ data class OffenderDetail(
     val surname: String? = null,
     val dateOfBirth: LocalDate? = null,
     val gender: String? = null,
-    val otherIds: IDs? = null,
     val currentDisposal: String? = null
 )
 
 data class IDs(
-    val crn: String? = null,
+    val crn: String,
     val pncNumber: String? = null,
     val croNumber: String? = null,
     val niNumber: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/MessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/MessageIntegrationTest.kt
@@ -49,9 +49,12 @@ class MessageIntegrationTest : QueueIntegrationTest() {
         await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
         await untilCallTo { eliteRequestCountFor("/api/bookings/1200835/sentenceDetail") } matches { it == 1 }
         await untilCallTo { eliteRequestCountFor("/api/bookings/1200835?basicInfo=true") } matches { it == 1 }
-        await untilCallTo { offenderSearchPostCountFor("/match") } matches { it == 1 }
+        // this will be 2 while we have additional analysis code in since we do everything twice
+        await untilCallTo { offenderSearchPostCountFor("/match") } matches { it == 2 }
+        await untilCallTo { communityGetCountFor("/secure/offenders/crn/X142620/convictions") } matches { it == 2 }
+        await untilCallTo { communityGetCountFor("/secure/offenders/crn/X181002/convictions") } matches { it == 2 }
         await untilCallTo { communityPutCountFor("/secure/offenders/nomsNumber/A5089DY/custody/bookingNumber") } matches { it == 1 }
-        await untilCallTo { mockingDetails(telemetryClient).invocations.size } matches { it == 2 }
+        await untilCallTo { mockingDetails(telemetryClient).invocations.size } matches { it == 3 }
 
         verify(telemetryClient).trackEvent(eq("P2PImprisonmentStatusUpdated"), any(), isNull())
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/QueueIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/QueueIntegrationTest.kt
@@ -22,5 +22,7 @@ class QueueIntegrationTest : IntegrationTest() {
 
     fun communityPostCountFor(url: String)= communityMockServer.findAll(postRequestedFor(urlEqualTo(url))).count()
 
+    fun communityGetCountFor(url: String)= communityMockServer.findAll(getRequestedFor(urlEqualTo(url))).count()
+
     fun offenderSearchPostCountFor(url: String)= searchMockServer.findAll(postRequestedFor(urlEqualTo(url))).count()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/CommunityServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisontoprobation.services
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
@@ -158,6 +159,25 @@ class CommunityServiceTest : IntegrationTest() {
     }
   }
 
+  @Nested
+  internal inner class GetConvictions{
+    @Test
+    fun `test get convictions calls rest endpoint`() {
+      val expectedConvictions = listOf(Conviction(index = "1", active = true))
+
+      communityMockServer.stubFor(WireMock.get(anyUrl()).willReturn(aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(expectedConvictions.asJson())
+          .withStatus(HTTP_OK)))
+
+
+      val convictions = service.getConvictions("X153626")
+
+      assertThat(convictions).isEqualTo(expectedConvictions)
+      communityMockServer.verify(WireMock.getRequestedFor(urlEqualTo("/secure/offenders/crn/X153626/convictions"))
+          .withHeader("Authorization", equalTo("Bearer ABCDE")))
+    }
+  }
   private fun createUpdatedCustody() = Custody(
       institution = Institution("Doncaster"),
       bookingNumber = "38353A"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/ImprisonmentStatusChangeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/ImprisonmentStatusChangeServiceTest.kt
@@ -24,7 +24,7 @@ class ImprisonmentStatusChangeServiceTest {
   inner class CheckImprisonmentStatusChangeAndUpdateProbation {
     @BeforeEach
     fun setUp() {
-      whenever(offenderProbationMatchService.ensureOffenderNumberExistsInProbation(any())).thenAnswer { Success((it.arguments[0] as Booking).offenderNo) }
+      whenever(offenderProbationMatchService.ensureOffenderNumberExistsInProbation(any(), any())).thenAnswer { Success((it.arguments[0] as Booking).offenderNo) }
     }
 
     @Nested
@@ -52,9 +52,10 @@ class ImprisonmentStatusChangeServiceTest {
       fun `will check offender exists in probation`() {
         val booking = createBooking()
         whenever(offenderService.getBooking(any())).thenReturn(booking)
+        whenever(offenderService.getSentenceDetail(any())).thenReturn(SentenceDetail(sentenceStartDate = LocalDate.parse("2020-01-30")))
 
         service.checkImprisonmentStatusChangeAndUpdateProbation(ImprisonmentStatusChangesMessage(12345L, 0L))
-        verify(offenderProbationMatchService).ensureOffenderNumberExistsInProbation(booking)
+        verify(offenderProbationMatchService).ensureOffenderNumberExistsInProbation(booking, LocalDate.parse("2020-01-30"))
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchServiceTest.kt
@@ -2,10 +2,13 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.services
 
 import com.microsoft.applicationinsights.TelemetryClient
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.atLeastOnce
 import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.isNull
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -17,46 +20,69 @@ internal class OffenderProbationMatchServiceTest {
   private val offenderSearchService: OffenderSearchService = mock()
   private val offenderService: OffenderService = mock()
   private val telemetryClient: TelemetryClient = mock()
-  private val service = OffenderProbationMatchService(telemetryClient, offenderSearchService, offenderService)
+  private val communityService: CommunityService = mock()
+  private val service = OffenderProbationMatchService(telemetryClient, offenderSearchService, offenderService, communityService)
 
   @BeforeEach
   fun setup() {
     whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf()))
     whenever(offenderService.getOffender(any())).thenReturn(prisonerOf())
+    whenever(communityService.getConvictions(any())).thenReturn(listOf())
   }
 
   @Test
-  fun `will call matching service using booking and offender details`() {
+  fun `will call matching service twice using booking and offender details`() {
     whenever(offenderService.getOffender(any())).thenReturn(prisonerOf(croNumber = "SF80/655108T", pncNumber = "18/0123456X"))
-    service.ensureOffenderNumberExistsInProbation(bookingOf(
-        offenderNo = "AB123D",
-        firstName = "John",
-        lastName = "Smith",
-        dateOfBirth = LocalDate.of(1965, 7, 19)
-    ))
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "AB123D",
+            firstName = "John",
+            lastName = "Smith",
+            dateOfBirth = LocalDate.of(1965, 7, 19)
+        ),
+        LocalDate.parse("2020-01-30")
+    )
 
-    verify(offenderSearchService).matchProbationOffender(check {
-      assertThat(it.activeSentence).isTrue()
-      assertThat(it.dateOfBirth).isEqualTo(LocalDate.of(1965, 7, 19))
-      assertThat(it.firstName).isEqualTo("John")
-      assertThat(it.surname).isEqualTo("Smith")
-      assertThat(it.nomsNumber).isEqualTo("AB123D")
-      assertThat(it.croNumber).isEqualTo("SF80/655108T")
-      assertThat(it.pncNumber).isEqualTo("18/0123456X")
-    })
+    val matchRequestCaptor = argumentCaptor<MatchRequest>()
+    verify(offenderSearchService, times(2)).matchProbationOffender(matchRequestCaptor.capture())
+
+
+    with(matchRequestCaptor.firstValue) {
+      assertThat(this.activeSentence).isTrue()
+      assertThat(this.dateOfBirth).isEqualTo(LocalDate.of(1965, 7, 19))
+      assertThat(this.firstName).isEqualTo("John")
+      assertThat(this.surname).isEqualTo("Smith")
+      assertThat(this.nomsNumber).isEqualTo("AB123D")
+      assertThat(this.croNumber).isEqualTo("SF80/655108T")
+      assertThat(this.pncNumber).isEqualTo("18/0123456X")
+    }
+
+    // analysis only call to check correctness of calling without NOMS number
+    with(matchRequestCaptor.secondValue) {
+      assertThat(this.activeSentence).isTrue()
+      assertThat(this.dateOfBirth).isEqualTo(LocalDate.of(1965, 7, 19))
+      assertThat(this.firstName).isEqualTo("John")
+      assertThat(this.surname).isEqualTo("Smith")
+      assertThat(this.nomsNumber).isEqualTo("")
+      assertThat(this.croNumber).isEqualTo("SF80/655108T")
+      assertThat(this.pncNumber).isEqualTo("18/0123456X")
+    }
   }
 
   @Test
   fun `will call matching service with null keyids when not present`() {
     whenever(offenderService.getOffender(any())).thenReturn(prisonerOf(croNumber = null, pncNumber = null))
-    service.ensureOffenderNumberExistsInProbation(bookingOf(
-        offenderNo = "AB123D",
-        firstName = "John",
-        lastName = "Smith",
-        dateOfBirth = LocalDate.of(1965, 7, 19)
-    ))
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "AB123D",
+            firstName = "John",
+            lastName = "Smith",
+            dateOfBirth = LocalDate.of(1965, 7, 19)
+        ),
+        LocalDate.parse("2020-01-30")
+    )
 
-    verify(offenderSearchService).matchProbationOffender(check {
+    verify(offenderSearchService, atLeastOnce()).matchProbationOffender(check {
       assertThat(it.pncNumber).isNull()
       assertThat(it.croNumber).isNull()
     })
@@ -64,24 +90,256 @@ internal class OffenderProbationMatchServiceTest {
 
   @Test
   fun `will return the offender number`() {
-    val offenderNo = service.ensureOffenderNumberExistsInProbation(bookingOf(
-        offenderNo = "A5089DY")).onIgnore { return }
+    val offenderNo = service.ensureOffenderNumberExistsInProbation(
+        bookingOf(offenderNo = "A5089DY"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
     assertThat(offenderNo).isEqualTo("A5089DY")
   }
 
   @Test
   fun `will send telemetry event with a match summary`() {
     whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))), OffenderMatch(OffenderDetail(otherIds = IDs(crn = "A12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+    whenever(communityService.getConvictions("A12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("1970-03-29"), custody = Custody(institution = null, bookingNumber = null))
+    )))
 
-    service.ensureOffenderNumberExistsInProbation(bookingOf(
-        offenderNo = "A5089DY",
-        bookingNo = "38339A")).onIgnore { return }
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
 
     verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
       assertThat(it["matches"]).isEqualTo("2")
-      assertThat(it["crns"]).isEqualTo("X12345, A12345")
+      assertThat(it["filtered_matches"]).isEqualTo("1")
+      assertThat(it["crns"]).isEqualTo("A12345, X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("X12345")
       assertThat(it["offenderNo"]).isEqualTo("A5089DY")
       assertThat(it["bookingNumber"]).isEqualTo("38339A")
+    }, isNull())
+  }
+
+  @Test
+  fun `will not filter out offenders that have a custody sentence starting on the same date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("X12345")
+    }, isNull())
+  }
+
+  @Test
+  fun `will not filter out offenders that have a custody sentence starting just before the same date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-23"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("X12345")
+    }, isNull())
+  }
+
+  @Test
+  fun `will not filter out offenders that have a custody sentence starting just after the same date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-02-06"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("X12345")
+    }, isNull())
+  }
+
+  @Test
+  fun `will filter out offenders that have a custody sentence starting a completely different date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2019-03-12"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("")
+    }, isNull())
+  }
+
+  @Test
+  fun `will filter out offenders that have a non-custodial sentence starting on same date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = null)
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("")
+    }, isNull())
+  }
+  @Test
+  fun `will filter out offenders that have an inactive custodial sentence starting on same date`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = false,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("")
+    }, isNull())
+  }
+
+  @Test
+  fun `will filter out offenders that have no sentence`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
+    whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = null
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X12345")
+      assertThat(it["filtered_crns"]).isEqualTo("")
+    }, isNull())
+  }
+
+  @Test
+  fun `will log differences between a NOMS number search and other id search`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(
+        OffenderMatches(listOf(
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00001"))),
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00002"))),
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00003")))
+        ))).thenReturn(
+        OffenderMatches(listOf(
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00002"))),
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00003"))),
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00004")))
+        ))
+    )
+    whenever(communityService.getConvictions(any())).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderImperfectMatch"), check {
+      assertThat(it["extra_crns"]).isEqualTo("X00004")
+      assertThat(it["crns"]).isEqualTo("X00002, X00003")
+      assertThat(it["missing_crns"]).isEqualTo("X00001")
+    }, isNull())
+  }
+
+  @Test
+  fun `will log a perfect match between a NOMS number search and other id search`() {
+    whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(
+        OffenderMatches(listOf(
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00001")))
+        ))).thenReturn(
+        OffenderMatches(listOf(
+            OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X00001")))
+        ))
+    )
+    whenever(communityService.getConvictions(any())).thenReturn(listOf(Conviction(
+        index = "1",
+        active = true,
+        sentence = Sentence(startDate = LocalDate.parse("2020-01-30"), custody = Custody(institution = null, bookingNumber = null))
+    )))
+
+    service.ensureOffenderNumberExistsInProbation(
+        bookingOf(
+            offenderNo = "A5089DY",
+            bookingNo = "38339A"),
+        LocalDate.parse("2020-01-30")
+    ).onIgnore { return }
+
+    verify(telemetryClient).trackEvent(eq("P2POffenderPerfectMatch"), check {
+      assertThat(it["crns"]).isEqualTo("X00001")
     }, isNull())
   }
 

--- a/src/test/resources/mappings/getConviction_X142620.json
+++ b/src/test/resources/mappings/getConviction_X142620.json
@@ -1,0 +1,154 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/secure/offenders/crn/X142620/convictions"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": [
+      {
+        "convictionId": 2500283547,
+        "index": "3",
+        "active": true,
+        "inBreach": false,
+        "convictionDate": "2020-01-24",
+        "referralDate": "2019-03-19",
+        "offences": [
+          {
+            "offenceId": "M2500283547",
+            "mainOffence": true,
+            "detail": {
+              "code": "01200",
+              "description": "Abandoning children under two years - 01200",
+              "mainCategoryCode": "012",
+              "mainCategoryDescription": "Abandoning children under two years",
+              "mainCategoryAbbreviation": "Abandoning children under two years",
+              "ogrsOffenceCategory": "Violence",
+              "subCategoryCode": "00",
+              "subCategoryDescription": "Abandoning children under two years",
+              "form20Code": "27"
+            },
+            "offenceDate": "2019-03-18T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2019-03-19T08:38:00",
+            "lastUpdatedDatetime": "2019-03-19T08:38:00"
+          }
+        ],
+        "sentence": {
+          "description": "CJA - Std Determinate Custody",
+          "originalLength": 10,
+          "originalLengthUnits": "Years",
+          "defaultLength": 120,
+          "lengthInDays": 3652,
+          "startDate": "2020-02-11"
+        },
+        "latestCourtAppearanceOutcome": {
+          "code": "301",
+          "description": "CJA - Std Determinate Custody"
+        },
+        "custody": {
+          "bookingNumber": "38353A",
+          "institution": {
+            "institutionId": 97,
+            "isEstablishment": true,
+            "code": "MDIHMP",
+            "description": "Moorland (HMP & YOI)",
+            "institutionName": "Moorland (HMP & YOI)",
+            "establishmentType": {
+              "code": "E",
+              "description": "Prison"
+            },
+            "nomsPrisonInstitutionCode": "MDI"
+          },
+          "keyDates": {
+            "conditionalReleaseDate": "2027-09-19",
+            "licenceExpiryDate": "2032-01-21",
+            "hdcEligibilityDate": "2026-07-24",
+            "paroleEligibilityDate": "2024-07-20",
+            "sentenceExpiryDate": "2035-01-20",
+            "expectedReleaseDate": "2027-09-19"
+          }
+        }
+      },
+      {
+        "convictionId": 2500258955,
+        "index": "1",
+        "active": true,
+        "inBreach": false,
+        "convictionDate": "2018-10-30",
+        "referralDate": "2018-10-04",
+        "offences": [
+          {
+            "offenceId": "M2500258955",
+            "mainOffence": true,
+            "detail": {
+              "code": "80500",
+              "description": "Accident offences - 80500",
+              "mainCategoryCode": "805",
+              "mainCategoryDescription": "Accident offences",
+              "mainCategoryAbbreviation": "Accident offences",
+              "ogrsOffenceCategory": "Other motoring",
+              "subCategoryCode": "00",
+              "subCategoryDescription": "Accident offences",
+              "form20Code": "13"
+            },
+            "offenceDate": "2018-10-01T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2018-10-05T12:13:43",
+            "lastUpdatedDatetime": "2018-10-05T12:13:43"
+          }
+        ],
+        "sentence": {
+          "description": "CJA - Community Order",
+          "originalLength": 12,
+          "originalLengthUnits": "Months",
+          "defaultLength": 12,
+          "lengthInDays": 364,
+          "startDate": "2018-10-31"
+        },
+        "latestCourtAppearanceOutcome": {
+          "code": "201",
+          "description": "CJA - Community Order"
+        }
+      },
+      {
+        "convictionId": 2500258960,
+        "index": "2",
+        "active": true,
+        "inBreach": false,
+        "referralDate": "2018-10-04",
+        "offences": [
+          {
+            "offenceId": "M2500258960",
+            "mainOffence": true,
+            "detail": {
+              "code": "15516",
+              "description": "Acting in a disruptive manner (Air Navigation) - 15516",
+              "mainCategoryCode": "155",
+              "mainCategoryDescription": "Air Force - offences associated with",
+              "mainCategoryAbbreviation": "Air Force - offences associated with",
+              "ogrsOffenceCategory": "Other offence",
+              "subCategoryCode": "16",
+              "subCategoryDescription": "Acting in a disruptive manner (Air Navigation)",
+              "form20Code": "15"
+            },
+            "offenceDate": "2018-10-03T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2018-10-05T12:26:35",
+            "lastUpdatedDatetime": "2018-10-05T12:26:35"
+          }
+        ],
+        "latestCourtAppearanceOutcome": {
+          "code": "101",
+          "description": "Adjourned - Pre-Sentence Report"
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/mappings/getConviction_X181002.json
+++ b/src/test/resources/mappings/getConviction_X181002.json
@@ -1,0 +1,154 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/secure/offenders/crn/X181002/convictions"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": [
+      {
+        "convictionId": 2500283547,
+        "index": "3",
+        "active": true,
+        "inBreach": false,
+        "convictionDate": "2020-01-24",
+        "referralDate": "2019-03-19",
+        "offences": [
+          {
+            "offenceId": "M2500283547",
+            "mainOffence": true,
+            "detail": {
+              "code": "01200",
+              "description": "Abandoning children under two years - 01200",
+              "mainCategoryCode": "012",
+              "mainCategoryDescription": "Abandoning children under two years",
+              "mainCategoryAbbreviation": "Abandoning children under two years",
+              "ogrsOffenceCategory": "Violence",
+              "subCategoryCode": "00",
+              "subCategoryDescription": "Abandoning children under two years",
+              "form20Code": "27"
+            },
+            "offenceDate": "2019-03-18T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2019-03-19T08:38:00",
+            "lastUpdatedDatetime": "2019-03-19T08:38:00"
+          }
+        ],
+        "sentence": {
+          "description": "CJA - Std Determinate Custody",
+          "originalLength": 10,
+          "originalLengthUnits": "Years",
+          "defaultLength": 120,
+          "lengthInDays": 3652,
+          "startDate": "2019-02-11"
+        },
+        "latestCourtAppearanceOutcome": {
+          "code": "301",
+          "description": "CJA - Std Determinate Custody"
+        },
+        "custody": {
+          "bookingNumber": "38353A",
+          "institution": {
+            "institutionId": 97,
+            "isEstablishment": true,
+            "code": "MDIHMP",
+            "description": "Moorland (HMP & YOI)",
+            "institutionName": "Moorland (HMP & YOI)",
+            "establishmentType": {
+              "code": "E",
+              "description": "Prison"
+            },
+            "nomsPrisonInstitutionCode": "MDI"
+          },
+          "keyDates": {
+            "conditionalReleaseDate": "2027-09-19",
+            "licenceExpiryDate": "2032-01-21",
+            "hdcEligibilityDate": "2026-07-24",
+            "paroleEligibilityDate": "2024-07-20",
+            "sentenceExpiryDate": "2035-01-20",
+            "expectedReleaseDate": "2027-09-19"
+          }
+        }
+      },
+      {
+        "convictionId": 2500258955,
+        "index": "1",
+        "active": true,
+        "inBreach": false,
+        "convictionDate": "2018-10-30",
+        "referralDate": "2018-10-04",
+        "offences": [
+          {
+            "offenceId": "M2500258955",
+            "mainOffence": true,
+            "detail": {
+              "code": "80500",
+              "description": "Accident offences - 80500",
+              "mainCategoryCode": "805",
+              "mainCategoryDescription": "Accident offences",
+              "mainCategoryAbbreviation": "Accident offences",
+              "ogrsOffenceCategory": "Other motoring",
+              "subCategoryCode": "00",
+              "subCategoryDescription": "Accident offences",
+              "form20Code": "13"
+            },
+            "offenceDate": "2018-10-01T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2018-10-05T12:13:43",
+            "lastUpdatedDatetime": "2018-10-05T12:13:43"
+          }
+        ],
+        "sentence": {
+          "description": "CJA - Community Order",
+          "originalLength": 12,
+          "originalLengthUnits": "Months",
+          "defaultLength": 12,
+          "lengthInDays": 364,
+          "startDate": "2018-10-31"
+        },
+        "latestCourtAppearanceOutcome": {
+          "code": "201",
+          "description": "CJA - Community Order"
+        }
+      },
+      {
+        "convictionId": 2500258960,
+        "index": "2",
+        "active": true,
+        "inBreach": false,
+        "referralDate": "2018-10-04",
+        "offences": [
+          {
+            "offenceId": "M2500258960",
+            "mainOffence": true,
+            "detail": {
+              "code": "15516",
+              "description": "Acting in a disruptive manner (Air Navigation) - 15516",
+              "mainCategoryCode": "155",
+              "mainCategoryDescription": "Air Force - offences associated with",
+              "mainCategoryAbbreviation": "Air Force - offences associated with",
+              "ogrsOffenceCategory": "Other offence",
+              "subCategoryCode": "16",
+              "subCategoryDescription": "Acting in a disruptive manner (Air Navigation)",
+              "form20Code": "15"
+            },
+            "offenceDate": "2018-10-03T00:00:00",
+            "offenceCount": 1,
+            "offenderId": 2500166978,
+            "createdDatetime": "2018-10-05T12:26:35",
+            "lastUpdatedDatetime": "2018-10-05T12:26:35"
+          }
+        ],
+        "latestCourtAppearanceOutcome": {
+          "code": "101",
+          "description": "Adjourned - Pre-Sentence Report"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
1. Add additional community-api call so we can check Delius also has a record of a custodial sentence starting roughly the same day as NOMIS
2 Add additional telemetry events so we can compare what would happen if we tried to match the offender who hasn't been matched manually before (e.g as if there is no NOMS number in Delius). This will tell us how accurate the matching algorithm is.