### PR TITLE
DT-644 Allow inactive events that maybe recalls for matching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
@@ -119,7 +119,6 @@ class OffenderProbationMatchService(
 
   private fun custodySentenceDates(crn: String): List<LocalDate> {
     return communityService.getConvictions(crn).asSequence()
-        .filter { conviction -> conviction.active }
         .filter { conviction -> conviction.custody?.let { true } ?: false }
         .map { conviction -> conviction.sentence }
         .filterNotNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchServiceTest.kt
@@ -245,7 +245,7 @@ internal class OffenderProbationMatchServiceTest {
     }, isNull())
   }
   @Test
-  fun `will filter out offenders that have an inactive custodial sentence starting on same date`() {
+  fun `will not filter out offenders that have an inactive custodial sentence starting on same date which maybe recalls`() {
     whenever(offenderSearchService.matchProbationOffender(any())).thenReturn(OffenderMatches(listOf(OffenderMatch(OffenderDetail(otherIds = IDs(crn = "X12345"))))))
     whenever(communityService.getConvictions("X12345")).thenReturn(listOf(Conviction(
         index = "1",
@@ -263,7 +263,7 @@ internal class OffenderProbationMatchServiceTest {
 
     verify(telemetryClient).trackEvent(eq("P2POffenderMatch"), check {
       assertThat(it["crns"]).isEqualTo("X12345")
-      assertThat(it["filtered_crns"]).isEqualTo("")
+      assertThat(it["filtered_crns"]).isEqualTo("X12345")
     }, isNull())
   }
 


### PR DESCRIPTION
Events (convictions) maybe inactive in Delius but the offender is still bought in as a recall on original sentence. So it is fine to match delius/nomis sentences even if they terminated in Delius