### PR TITLE
DT-768 Send all data to Delius on imprisonment status change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/OffenderProbationMatchService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisontoprobation.services
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.Result.Ignore
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.Result.Success
@@ -15,7 +16,8 @@ class OffenderProbationMatchService(
     private val telemetryClient: TelemetryClient,
     private val offenderSearchService: OffenderSearchService,
     private val offenderService: OffenderService,
-    private val communityService: CommunityService
+    private val communityService: CommunityService,
+    @Value("\${prisontoprobation.only.prisons}") private val allowedPrisons: List<String>
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -62,17 +64,21 @@ class OffenderProbationMatchService(
         when (filteredCRNs.size) {
           0 -> Ignore(TelemetryEvent(name = "P2POffenderNoMatch", attributes = mapOf("offenderNo" to booking.offenderNo, "crns" to result.CRNs())))
           1 -> {
-            communityService.updateProbationOffenderNo(filteredCRNs.first(), booking.offenderNo)
-            telemetryClient.trackEvent(
-                "P2POffenderNumberSet",
-                mapOf(
-                    "offenderNo" to booking.offenderNo,
-                    "bookingNumber" to booking.bookingNo,
-                    "crn" to filteredCRNs.first()
-                ),
-                null
-            )
-            Success(booking.offenderNo)
+            return if (isBookingInInterestedPrison(booking.agencyId)) {
+              communityService.updateProbationOffenderNo(filteredCRNs.first(), booking.offenderNo)
+              telemetryClient.trackEvent(
+                  "P2POffenderNumberSet",
+                  mapOf(
+                      "offenderNo" to booking.offenderNo,
+                      "bookingNumber" to booking.bookingNo,
+                      "crn" to filteredCRNs.first()
+                  ),
+                  null
+              )
+              Success(booking.offenderNo)
+            } else {
+              Ignore(TelemetryEvent("P2PChangeIgnored", mapOf("reason" to "Not at an interested prison")))
+            }
           }
           else -> Ignore(TelemetryEvent(name = "P2POffenderTooManyMatches", attributes = mapOf("offenderNo" to booking.offenderNo, "filtered_crns" to filteredCRNs.sorted().joinToString())))
         }
@@ -148,6 +154,11 @@ class OffenderProbationMatchService(
         .filterNotNull()
         .toList()
   }
+
+  private fun isBookingInInterestedPrison(toAgency: String?) =
+      allowAnyPrison() || allowedPrisons.contains(toAgency)
+
+  private fun allowAnyPrison() = allowedPrisons.isEmpty()
 }
 
 private fun LocalDate.closeTo(date: LocalDate, days: Int = 7): Boolean = Math.abs(DAYS.between(this, date)) <= days

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/SentenceDatesChangeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/SentenceDatesChangeService.kt
@@ -57,7 +57,7 @@ class SentenceDatesChangeService(
 
 }
 
-private fun SentenceDetail.asProbationKeyDates(): ReplaceCustodyKeyDates = ReplaceCustodyKeyDates(
+fun SentenceDetail.asProbationKeyDates(): ReplaceCustodyKeyDates = ReplaceCustodyKeyDates(
     conditionalReleaseDate = conditionalReleaseOverrideDate ?: this.conditionalReleaseDate,
     sentenceExpiryDate = sentenceExpiryDate,
     paroleEligibilityDate = paroleEligibilityDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/MessageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/MessageIntegrationTest.kt
@@ -40,6 +40,9 @@ class MessageIntegrationTest : QueueIntegrationTest() {
     await untilCallTo { communityGetCountFor("/secure/offenders/crn/X181002/convictions") } matches { it == 2 }
     await untilCallTo { communityPutCountFor("/secure/offenders/crn/X142620/nomsNumber") } matches { it == 1 }
     await untilCallTo { communityPutCountFor("/secure/offenders/nomsNumber/A5089DY/custody/bookingNumber") } matches { it == 1 }
+    await untilCallTo { communityPutCountFor("/secure/offenders/nomsNumber/A5089DY/custody/bookingNumber/38339A") } matches { it == 1 }
+    await untilCallTo { communityPostCountFor("/secure/offenders/nomsNumber/A5089DY/bookingNumber/38339A/custody/keyDates") } matches { it == 1 }
+
   }
 
   @Test


### PR DESCRIPTION
1. Feature switch so we only update Delius NOMS Numbers if the prison is "switched on"
2. On an imprisonment status change refresh all custody data as if the offender has just been sentenced, this so that a offender just from court will have prison and court dates updated even though they change earlier in NOMIS