### PR TITLE
DT-909 Fixed issue where 2 duplicate messages fired at same time we not de-duplicated

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/MessageAggregatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/MessageAggregatorTest.kt
@@ -56,7 +56,7 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will do nothing when no "first time" messages need processing`() {
-    repository.save(Message(bookingId = 99L, retryCount = 1, createdDate = LocalDateTime.now(), eventType = "IMPRISONMENT_STATUS-CHANGED", message = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":1200835,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 1, createdDate = LocalDateTime.now(), eventType = "IMPRISONMENT_STATUS-CHANGED", message = imprisonmentStatusChangedMessage(1200835)))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -65,7 +65,7 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will do nothing when no recent "first time" messages need processing`() {
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "IMPRISONMENT_STATUS-CHANGED", message = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":1200835,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "IMPRISONMENT_STATUS-CHANGED", message = imprisonmentStatusChangedMessage(1200835)))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -74,8 +74,8 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will process when a single old "first time" messages need processing`() {
-    val message = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":1200835,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "IMPRISONMENT_STATUS-CHANGED", message = message))
+    val message = imprisonmentStatusChangedMessage(1200835)
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "IMPRISONMENT_STATUS-CHANGED", message = message))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -84,34 +84,34 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will process messages in any order for each booking batch`() {
-    val tooYoungMessage = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":99,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "IMPRISONMENT_STATUS-CHANGED", message = tooYoungMessage))
-    val youngMessage = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":100,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
+    val tooYoungMessage = imprisonmentStatusChangedMessage(99)
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "IMPRISONMENT_STATUS-CHANGED", message = tooYoungMessage))
+    val youngMessage = imprisonmentStatusChangedMessage(100)
     repository.save(Message(bookingId = 100L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "IMPRISONMENT_STATUS-CHANGED", message = youngMessage))
-    val veryOldMessage = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":999,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 999L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(99), eventType = "IMPRISONMENT_STATUS-CHANGED", message = veryOldMessage))
-    val oldMessage = "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":101,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
+    val veryOldMessage = imprisonmentStatusChangedMessage(999)
+    repository.save(Message(bookingId = 999, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(99), eventType = "IMPRISONMENT_STATUS-CHANGED", message = veryOldMessage))
+    val oldMessage = imprisonmentStatusChangedMessage(101)
     repository.save(Message(bookingId = 101L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(20), eventType = "IMPRISONMENT_STATUS-CHANGED", message = oldMessage))
 
     messageAggregator.processMessagesForNextBookingSets()
 
-    verify(messageProcessor).processMessage("IMPRISONMENT_STATUS-CHANGED", veryOldMessage)
     verify(messageProcessor).processMessage("IMPRISONMENT_STATUS-CHANGED", oldMessage)
     verify(messageProcessor).processMessage("IMPRISONMENT_STATUS-CHANGED", youngMessage)
+    verify(messageProcessor).processMessage("IMPRISONMENT_STATUS-CHANGED", veryOldMessage)
     verify(messageProcessor, never()).processMessage("IMPRISONMENT_STATUS-CHANGED", tooYoungMessage)
   }
 
   @Test
   fun `will process messages in date order within group of bookings`() {
-    val youngSentenceChangeMessage = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":999,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 999L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "SENTENCE_DATES-CHANGED", message = youngSentenceChangeMessage))
-    val tooYoungMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":99,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = tooYoungMessage))
-    val youngMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":100,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
+    val youngSentenceChangeMessage = sentenceDatesChangedMessage(999)
+    repository.save(Message(bookingId = 999, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "SENTENCE_DATES-CHANGED", message = youngSentenceChangeMessage))
+    val tooYoungMessage = externalMovementInsertedMessage(99)
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(1), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = tooYoungMessage))
+    val youngMessage = externalMovementInsertedMessage(100)
     repository.save(Message(bookingId = 100L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = youngMessage))
-    val veryOldMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":999,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
-    repository.save(Message(bookingId = 999L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(99), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = veryOldMessage))
-    val oldMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":101,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
+    val veryOldMessage = externalMovementInsertedMessage(999)
+    repository.save(Message(bookingId = 999, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(99), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = veryOldMessage))
+    val oldMessage = externalMovementInsertedMessage(101)
     repository.save(Message(bookingId = 101L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(20), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = oldMessage))
 
     messageAggregator.processMessagesForNextBookingSets()
@@ -125,11 +125,25 @@ internal class MessageAggregatorTest {
   }
 
   @Test
+  fun `will process messages even if they are in a retry state in date order within group of bookings`() {
+    val sentenceChangeMessage = sentenceDatesChangedMessage(999)
+    repository.save(Message(bookingId = 999, retryCount = 9, createdDate = LocalDateTime.now().minusDays(1), eventType = "SENTENCE_DATES-CHANGED", message = sentenceChangeMessage))
+    val externalMovementMessage = externalMovementInsertedMessage(999)
+    repository.save(Message(bookingId = 999, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(99), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = externalMovementMessage))
+
+    messageAggregator.processMessagesForNextBookingSets()
+
+    val orderVerifier = inOrder(messageProcessor)
+    orderVerifier.verify(messageProcessor).processMessage("EXTERNAL_MOVEMENT_RECORD-INSERTED", externalMovementMessage)
+    orderVerifier.verify(messageProcessor).processMessage("SENTENCE_DATES-CHANGED", sentenceChangeMessage)
+  }
+
+  @Test
   fun `will process all other messages for a booking when old "first time" messages need processing regardless of age`() {
-    val prisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"
-    val sentenceDateChangeMessage = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage))
+    val prisonLocationChangeMessage = externalMovementInsertedMessage(99)
+    val sentenceDateChangeMessage = sentenceDatesChangedMessage(99)
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -139,12 +153,12 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will de-duplicate the messages prior to processing`() {
-    val prisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"
-    val sentenceDateChangeMessage1 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"
-    val sentenceDateChangeMessage2 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:33.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628784,\"nomisEventType\":\"S2_RESULT\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
+    val prisonLocationChangeMessage = externalMovementInsertedMessage(99)
+    val sentenceDateChangeMessage1 = sentenceDatesChangedMessage(99, "2020-02-25T11:24:32.935401")
+    val sentenceDateChangeMessage2 = sentenceDatesChangedMessage(99, "2020-02-25T11:24:33.935401")
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -154,10 +168,10 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will de-duplicate old messages prior to processing`() {
-    val sentenceDateChangeMessage1 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"
-    val sentenceDateChangeMessage2 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:33.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628784,\"nomisEventType\":\"S2_RESULT\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
+    val sentenceDateChangeMessage1 = sentenceDatesChangedMessage(99, "2020-02-25T11:24:32.935401")
+    val sentenceDateChangeMessage2 = sentenceDatesChangedMessage(99, "2020-02-25T11:24:33.935401")
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
 
 
     messageAggregator.processMessagesForNextBookingSets()
@@ -167,13 +181,13 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will process the latest of duplicated old messages prior to processing`() {
-    val oldestPrisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"
-    val latestPrisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":3,\"nomisEventType\":\"M1_RESULT\"}"
-    val middlePrisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":2,\"nomisEventType\":\"M1_RESULT\"}"
+    val oldestPrisonLocationChangeMessage = externalMovementInsertedMessage(99, 1)
+    val latestPrisonLocationChangeMessage = externalMovementInsertedMessage(99, 3)
+    val middlePrisonLocationChangeMessage = externalMovementInsertedMessage(99, 2)
 
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(15), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = oldestPrisonLocationChangeMessage))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(13), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = latestPrisonLocationChangeMessage))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(14), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = middlePrisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(15), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = oldestPrisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(13), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = latestPrisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(14), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = middlePrisonLocationChangeMessage))
 
     messageAggregator.processMessagesForNextBookingSets()
 
@@ -182,12 +196,12 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `will only process message once each is successfully processed`() {
-    val prisonLocationChangeMessage = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"
-    val sentenceDateChangeMessage1 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"
-    val sentenceDateChangeMessage2 = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:33.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628784,\"nomisEventType\":\"S2_RESULT\"}"
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
+    val prisonLocationChangeMessage = externalMovementInsertedMessage(99)
+    val sentenceDateChangeMessage1 = sentenceDatesChangedMessage(99)
+    val sentenceDateChangeMessage2 = sentenceDatesChangedMessage(99)
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = prisonLocationChangeMessage))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage1))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDateChangeMessage2))
 
     messageAggregator.processMessagesForNextBookingSets()
     verify(messageProcessor, times(2)).processMessage(any(), any())
@@ -199,8 +213,8 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `no messages will be retried if all successful`() {
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = externalMovementInsertedMessage(99)))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDatesChangedMessage(99)))
 
     messageAggregator.processMessagesForNextBookingSets()
     verify(messageProcessor, times(2)).processMessage(any(), any())
@@ -217,8 +231,8 @@ internal class MessageAggregatorTest {
   fun `all messages will be retried if all fail with unexpected exceptions`() {
     whenever(messageProcessor.processMessage(any(), any())).thenThrow(RuntimeException("oops"))
 
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = externalMovementInsertedMessage(99)))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDatesChangedMessage(99)))
 
     messageAggregator.processMessagesForNextBookingSets()
     verify(messageProcessor, times(2)).processMessage(any(), any())
@@ -234,8 +248,8 @@ internal class MessageAggregatorTest {
         .thenThrow(RuntimeException("oops"))
         .thenReturn(Done())
 
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = externalMovementInsertedMessage(99)))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDatesChangedMessage(99)))
 
     messageAggregator.processMessagesForNextBookingSets()
     verify(messageProcessor, times(2)).processMessage(any(), any())
@@ -247,10 +261,10 @@ internal class MessageAggregatorTest {
 
   @Test
   fun `all messages will be retried if all require to be retried`() {
-    whenever(messageProcessor.processMessage(any(), any())).thenReturn(TryLater(99L))
+    whenever(messageProcessor.processMessage(any(), any())).thenReturn(TryLater(99))
 
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":99,\"movementSeq\":1,\"nomisEventType\":\"M1_RESULT\"}"))
-    repository.save(Message(bookingId = 99L, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"2020-02-25T11:24:32.935401\",\"bookingId\":99,\"sentenceCalculationId\":5628783,\"nomisEventType\":\"S2_RESULT\"}"))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now().minusMinutes(11), eventType = "EXTERNAL_MOVEMENT_RECORD-INSERTED", message = externalMovementInsertedMessage(99)))
+    repository.save(Message(bookingId = 99, retryCount = 0, createdDate = LocalDateTime.now(), eventType = "SENTENCE_DATES-CHANGED", message = sentenceDatesChangedMessage(99)))
 
     messageAggregator.processMessagesForNextBookingSets()
     verify(messageProcessor, times(2)).processMessage(any(), any())
@@ -260,4 +274,12 @@ internal class MessageAggregatorTest {
     verify(messageProcessor, times(2)).processMessage(any(), any())
   }
 
+  private fun sentenceDatesChangedMessage(bookingId: Long, eventDateTime: String = "2020-02-12T15:14:24.125533"): String =
+      "{\"eventType\":\"SENTENCE_DATES-CHANGED\",\"eventDatetime\":\"$eventDateTime\",\"bookingId\":$bookingId,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
+  
+  private fun externalMovementInsertedMessage(bookingId: Long, movementSeq: Int = 1): String = 
+      "{\"eventType\":\"EXTERNAL_MOVEMENT_RECORD-INSERTED\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"bookingId\":$bookingId,\"movementSeq\":$movementSeq,\"nomisEventType\":\"M1_RESULT\"}"
+
+  private fun imprisonmentStatusChangedMessage(bookingId: Long) : String =
+      "{\"eventType\":\"IMPRISONMENT_STATUS-CHANGED\",\"eventDatetime\":\"2020-02-12T15:14:24.125533\",\"bookingId\":$bookingId,\"nomisEventType\":\"OFF_IMP_STAT_OASYS\"}"
 }


### PR DESCRIPTION
System processed correctly the following scenario

Scenario 1
SENTENCE_DATES-CHANGED received 10 minutes ago
SENTENCE_DATES-CHANGED received 5 minutes ago
Only one was correctly processed

Scenario 2
SENTENCE_DATES-CHANGED received 10 minutes ago
SENTENCE_DATES-CHANGED received also exactly 10 minutes ago
Both would have been processed