### PR TITLE
Dt 853 spilt tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,7 @@ jobs:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_test_results:
-          paths:
-            - build/unit/test-results
-            - build/integration/test-results
+          path: build/test-results
       - store_artifacts:
           path: build/reports/tests
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           environment:
             AWS_PROVIDER: localstack
-          command: ./gradlew test
+          command: ./gradlew test -Dtest.profile=unit
       - run:
           environment:
             AWS_PROVIDER: localstack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
           environment:
             AWS_PROVIDER: localstack
           command: ./gradlew test
+      - run:
+          environment:
+            AWS_PROVIDER: localstack
+          command: ./gradlew test -Dtest.profile=integration
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,9 @@ jobs:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_test_results:
-          path: build/test-results
+          paths:
+            - build/unit/test-results
+            - build/integration/test-results
       - store_artifacts:
           path: build/reports/tests
       - persist_to_workspace:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ tasks.withType<Test> {
     exclude("**/*MessageIntegrationTest*")
   }
   if (System.getProperty("test.profile") == "integration") {
+    testResultDirs("build/reports/integration-tests")
     include("**/*MessageIntegrationTest*")
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,12 +49,12 @@ tasks.withType<Test> {
   }
 }
 if (System.getProperty("test.profile") == "integration") {
-  reporting.baseDir = File("build/reports/tests/integration")
-  project.setProperty("testResultsDirName", "$buildDir/integration")
+  reporting.baseDir = File("$buildDir/reports/tests/integration")
+  project.setProperty("testResultsDirName", "$buildDir/test-results/integration")
 }
 
 if (System.getProperty("test.profile") == "unit") {
-  reporting.baseDir = File("build/reports/tests/unit")
-  project.setProperty("testResultsDirName", "$buildDir/unit")
+  reporting.baseDir = File("$buildDir/reports/tests/unit")
+  project.setProperty("testResultsDirName", "$buildDir/test-results/unit")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,3 +39,12 @@ dependencies {
   testImplementation("org.testcontainers:localstack:1.14.3")
   testImplementation("org.awaitility:awaitility-kotlin:4.0.3")
 }
+
+tasks.withType<Test> {
+  if (System.getProperty("test.profile") != "integration") {
+    exclude("**/*MessageIntegrationTest*")
+  }
+  if (System.getProperty("test.profile") == "integration") {
+    include("**/*MessageIntegrationTest*")
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,11 @@ tasks.withType<Test> {
 }
 if (System.getProperty("test.profile") == "integration") {
   reporting.baseDir = File("build/reports/tests/integration")
+  project.setProperty("testResultsDirName", "$buildDir/integration")
 }
 
 if (System.getProperty("test.profile") == "unit") {
   reporting.baseDir = File("build/reports/tests/unit")
+  project.setProperty("testResultsDirName", "$buildDir/unit")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,11 +41,18 @@ dependencies {
 }
 
 tasks.withType<Test> {
-  if (System.getProperty("test.profile") != "integration") {
+  if (System.getProperty("test.profile") == "unit") {
     exclude("**/*MessageIntegrationTest*")
   }
   if (System.getProperty("test.profile") == "integration") {
-    testResultDirs("build/reports/integration-tests")
     include("**/*MessageIntegrationTest*")
   }
 }
+if (System.getProperty("test.profile") == "integration") {
+  reporting.baseDir = File("build/reports/tests/integration")
+}
+
+if (System.getProperty("test.profile") == "unit") {
+  reporting.baseDir = File("build/reports/tests/unit")
+}
+


### PR DESCRIPTION
The purpose of this test is a workaround where by MessageIntegrationTest is often using an invalid Spring context with mocks rather than real beans. All solutions with DirtiesContext, Profiles, SpyBeans have been unsuccessful on this interment issue.

Tactical solution it to run the problematic test in its own gradle run.