### PR TITLE
DT-1586 Allow import of Open Api docs in postman

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/OpenApiConfiguration.kt
@@ -8,11 +8,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class OpenApiConfiguration {
+class OpenApiConfiguration(buildProperties: BuildProperties) {
+  private val version: String = buildProperties.version
+
   @Bean
-  fun customOpenAPI(buildProperties: BuildProperties): OpenAPI = OpenAPI()
+  fun customOpenAPI(): OpenAPI = OpenAPI()
     .info(
       Info().title("Prison to Probation update service")
+        .version(version)
         .description("A service that synchronises prison custody data to Delius")
         .contact(Contact().name("HMPPS Digital Studio").email("feedback@digital.justice.gov.uk"))
     )


### PR DESCRIPTION
I tried including some tests for the open api docs but that caused a severe bout of DT-1465 (RejectedExecutionException from, Netty).  So for now I'll merge this fix and investigate the new symptoms of the Netty issue.