### PR TITLE
DT-2215 switch from deprecated API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   implementation(platform("com.amazonaws:aws-java-sdk-bom:1.11.1020"))
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
   implementation("com.amazonaws:aws-java-sdk-sns")
-  implementation("uk.gov.justice.service.hmpps:hmpps-spring-boot-sqs:0.3.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-spring-boot-sqs:0.3.2")
   implementation("com.amazonaws:aws-java-sdk-dynamodb")
   implementation("io.github.boostchicken:spring-data-dynamodb:5.2.5")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Configuration
@@ -23,16 +22,7 @@ class AwsSqsConfig(private val hmppsQueueService: HmppsQueueService) {
     with(sqsConfigProperties) {
       amazonSQS(dpsQueue.queueAccessKeyId, dpsQueue.queueSecretAccessKey, region)
         .also { log.info("Created aws sqs client for queue ${dpsQueue.queueName}") }
-        .also {
-          hmppsQueueService.registerHmppsQueue(
-            HmppsQueue(
-              it,
-              sqsConfigProperties.dpsQueue.queueName,
-              awsSqsDlqClient,
-              sqsConfigProperties.dpsQueue.dlqName
-            )
-          )
-        }
+        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue.queueName, awsSqsDlqClient, dpsQueue.dlqName) }
     }
 
   @Bean
@@ -40,16 +30,7 @@ class AwsSqsConfig(private val hmppsQueueService: HmppsQueueService) {
     with(sqsConfigProperties) {
       amazonSQS(hmppsQueue.queueAccessKeyId, hmppsQueue.queueSecretAccessKey, region)
         .also { log.info("Created aws sqs client for queue ${hmppsQueue.queueName}") }
-        .also {
-          hmppsQueueService.registerHmppsQueue(
-            HmppsQueue(
-              it,
-              sqsConfigProperties.hmppsQueue.queueName,
-              hmppsAwsSqsDlqClient,
-              sqsConfigProperties.hmppsQueue.dlqName
-            )
-          )
-        }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue.queueName, hmppsAwsSqsDlqClient, hmppsQueue.dlqName) }
     }
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
@@ -20,31 +20,31 @@ class AwsSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   @Bean
   fun awsSqsClient(sqsConfigProperties: SqsConfigProperties, awsSqsDlqClient: AmazonSQS): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(dpsQueue.queueAccessKeyId, dpsQueue.queueSecretAccessKey, region)
-        .also { log.info("Created aws sqs client for queue ${dpsQueue.queueName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue.queueName, awsSqsDlqClient, dpsQueue.dlqName) }
+      amazonSQS(dpsQueue().queueAccessKeyId, dpsQueue().queueSecretAccessKey, region)
+        .also { log.info("Created aws sqs client for queue ${dpsQueue().queueName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue().queueName, awsSqsDlqClient, dpsQueue().dlqName) }
     }
 
   @Bean
   fun hmppsAwsSqsClient(sqsConfigProperties: SqsConfigProperties, hmppsAwsSqsDlqClient: AmazonSQS): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(hmppsQueue.queueAccessKeyId, hmppsQueue.queueSecretAccessKey, region)
-        .also { log.info("Created aws sqs client for queue ${hmppsQueue.queueName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue.queueName, hmppsAwsSqsDlqClient, hmppsQueue.dlqName) }
+      amazonSQS(hmppsQueue().queueAccessKeyId, hmppsQueue().queueSecretAccessKey, region)
+        .also { log.info("Created aws sqs client for queue ${hmppsQueue().queueName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue().queueName, hmppsAwsSqsDlqClient, hmppsQueue().dlqName) }
     }
 
   @Bean
   fun awsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(dpsQueue.dlqAccessKeyId, dpsQueue.dlqSecretAccessKey, region)
-        .also { log.info("Created aws dlq sqs client for dlq ${dpsQueue.dlqName}") }
+      amazonSQS(dpsQueue().dlqAccessKeyId, dpsQueue().dlqSecretAccessKey, region)
+        .also { log.info("Created aws dlq sqs client for dlq ${dpsQueue().dlqName}") }
     }
 
   @Bean
   fun hmppsAwsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(hmppsQueue.dlqAccessKeyId, hmppsQueue.dlqSecretAccessKey, region)
-        .also { log.info("Created aws dlq sqs client for dlq ${hmppsQueue.dlqName}") }
+      amazonSQS(hmppsQueue().dlqAccessKeyId, hmppsQueue().dlqSecretAccessKey, region)
+        .also { log.info("Created aws dlq sqs client for dlq ${hmppsQueue().dlqName}") }
     }
 
   private fun amazonSQS(accessKeyId: String, secretAccessKey: String, region: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/AwsSqsConfig.kt
@@ -20,31 +20,31 @@ class AwsSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   @Bean
   fun awsSqsClient(sqsConfigProperties: SqsConfigProperties, awsSqsDlqClient: AmazonSQS): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(dpsQueue().queueAccessKeyId, dpsQueue().queueSecretAccessKey, region)
-        .also { log.info("Created aws sqs client for queue ${dpsQueue().queueName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue().queueName, awsSqsDlqClient, dpsQueue().dlqName) }
+      amazonSQS(prisonEventQueue().queueAccessKeyId, prisonEventQueue().queueSecretAccessKey, region)
+        .also { log.info("Created aws sqs client for queue ${prisonEventQueue().queueName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, prisonEventQueue().queueName, awsSqsDlqClient, prisonEventQueue().dlqName) }
     }
 
   @Bean
   fun hmppsAwsSqsClient(sqsConfigProperties: SqsConfigProperties, hmppsAwsSqsDlqClient: AmazonSQS): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(hmppsQueue().queueAccessKeyId, hmppsQueue().queueSecretAccessKey, region)
-        .also { log.info("Created aws sqs client for queue ${hmppsQueue().queueName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue().queueName, hmppsAwsSqsDlqClient, hmppsQueue().dlqName) }
+      amazonSQS(hmppsDomainEventQueue().queueAccessKeyId, hmppsDomainEventQueue().queueSecretAccessKey, region)
+        .also { log.info("Created aws sqs client for queue ${hmppsDomainEventQueue().queueName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsDomainEventQueue().queueName, hmppsAwsSqsDlqClient, hmppsDomainEventQueue().dlqName) }
     }
 
   @Bean
   fun awsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(dpsQueue().dlqAccessKeyId, dpsQueue().dlqSecretAccessKey, region)
-        .also { log.info("Created aws dlq sqs client for dlq ${dpsQueue().dlqName}") }
+      amazonSQS(prisonEventQueue().dlqAccessKeyId, prisonEventQueue().dlqSecretAccessKey, region)
+        .also { log.info("Created aws dlq sqs client for dlq ${prisonEventQueue().dlqName}") }
     }
 
   @Bean
   fun hmppsAwsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
-      amazonSQS(hmppsQueue().dlqAccessKeyId, hmppsQueue().dlqSecretAccessKey, region)
-        .also { log.info("Created aws dlq sqs client for dlq ${hmppsQueue().dlqName}") }
+      amazonSQS(hmppsDomainEventQueue().dlqAccessKeyId, hmppsDomainEventQueue().dlqSecretAccessKey, region)
+        .also { log.info("Created aws dlq sqs client for dlq ${hmppsDomainEventQueue().dlqName}") }
     }
 
   private fun amazonSQS(accessKeyId: String, secretAccessKey: String, region: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Configuration
@@ -49,16 +48,7 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
           )
         }
         .also { log.info("Queue ${dpsQueue.queueName} has subscribed to dps topic ${dpsQueue.topicName}") }
-        .also {
-          hmppsQueueService.registerHmppsQueue(
-            HmppsQueue(
-              it,
-              sqsConfigProperties.dpsQueue.queueName,
-              awsSqsDlqClient,
-              sqsConfigProperties.dpsQueue.dlqName
-            )
-          )
-        }
+        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue.queueName, awsSqsDlqClient, dpsQueue.dlqName) }
     }
 
   @Bean("awsSqsDlqClient")
@@ -94,16 +84,7 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
           )
         }
         .also { log.info("Queue ${hmppsQueue.queueName} has subscribed to hmpps topic ${hmppsQueue.topicName}") }
-        .also {
-          hmppsQueueService.registerHmppsQueue(
-            HmppsQueue(
-              it,
-              sqsConfigProperties.hmppsQueue.queueName,
-              hmppsAwsSqsDlqClient,
-              sqsConfigProperties.hmppsQueue.dlqName
-            )
-          )
-        }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue.queueName, hmppsAwsSqsDlqClient, hmppsQueue.dlqName) }
     }
 
   @Bean("hmppsAwsSqsDlqClient")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
@@ -27,8 +27,8 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   fun awsSnsClient(sqsConfigProperties: SqsConfigProperties): AmazonSNS =
     with(sqsConfigProperties) {
       localstackAmazonSNS(localstackUrl, region)
-        .also { snsClient -> snsClient.createTopic(dpsQueue().topicName) }
-        .also { log.info("Created localstack sns topic with name ${dpsQueue().topicName}") }
+        .also { snsClient -> snsClient.createTopic(prisonEventQueue().topicName) }
+        .also { log.info("Created localstack sns topic with name ${prisonEventQueue().topicName}") }
     }
 
   @Bean("awsSqsClient")
@@ -39,32 +39,32 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   ): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { sqsClient -> createMainQueue(sqsClient, awsSqsDlqClient, dpsQueue().queueName, dpsQueue().dlqName) }
-        .also { log.info("Created localstack sqs client for queue ${dpsQueue().queueName}") }
+        .also { sqsClient -> createMainQueue(sqsClient, awsSqsDlqClient, prisonEventQueue().queueName, prisonEventQueue().dlqName) }
+        .also { log.info("Created localstack sqs client for queue ${prisonEventQueue().queueName}") }
         .also {
           subscribeToTopic(
-            awsSnsClient, localstackUrl, region, dpsQueue().topicName, dpsQueue().queueName,
+            awsSnsClient, localstackUrl, region, prisonEventQueue().topicName, prisonEventQueue().queueName,
             mapOf("FilterPolicy" to """{"eventType":[ "EXTERNAL_MOVEMENT_RECORD-INSERTED", "IMPRISONMENT_STATUS-CHANGED", "SENTENCE_DATES-CHANGED", "BOOKING_NUMBER-CHANGED"] }""")
           )
         }
-        .also { log.info("Queue ${dpsQueue().queueName} has subscribed to dps topic ${dpsQueue().topicName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue().queueName, awsSqsDlqClient, dpsQueue().dlqName) }
+        .also { log.info("Queue ${prisonEventQueue().queueName} has subscribed to dps topic ${prisonEventQueue().topicName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, prisonEventQueue().queueName, awsSqsDlqClient, prisonEventQueue().dlqName) }
     }
 
   @Bean("awsSqsDlqClient")
   fun awsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { dlqSqsClient -> dlqSqsClient.createQueue(dpsQueue().dlqName) }
-        .also { log.info("Created localstack dlq sqs client for dlq ${dpsQueue().dlqName}") }
+        .also { dlqSqsClient -> dlqSqsClient.createQueue(prisonEventQueue().dlqName) }
+        .also { log.info("Created localstack dlq sqs client for dlq ${prisonEventQueue().dlqName}") }
     }
 
   @Bean
   fun hmppsAwsSnsClient(sqsConfigProperties: SqsConfigProperties): AmazonSNS =
     with(sqsConfigProperties) {
       localstackAmazonSNS(sqsConfigProperties.localstackUrl, sqsConfigProperties.region)
-        .also { snsClient -> snsClient.createTopic(hmppsQueue().topicName) }
-        .also { log.info("Created localstack sns topic with name ${hmppsQueue().topicName}") }
+        .also { snsClient -> snsClient.createTopic(hmppsDomainEventQueue().topicName) }
+        .also { log.info("Created localstack sns topic with name ${hmppsDomainEventQueue().topicName}") }
     }
 
   @Bean("hmppsAwsSqsClient")
@@ -75,24 +75,24 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   ): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { sqsClient -> createMainQueue(sqsClient, hmppsAwsSqsDlqClient, hmppsQueue().queueName, hmppsQueue().dlqName) }
-        .also { log.info("Created localstack sqs client for queue ${hmppsQueue().queueName}") }
+        .also { sqsClient -> createMainQueue(sqsClient, hmppsAwsSqsDlqClient, hmppsDomainEventQueue().queueName, hmppsDomainEventQueue().dlqName) }
+        .also { log.info("Created localstack sqs client for queue ${hmppsDomainEventQueue().queueName}") }
         .also {
           subscribeToTopic(
-            hmppsAwsSnsClient, localstackUrl, region, hmppsQueue().topicName, hmppsQueue().queueName,
+            hmppsAwsSnsClient, localstackUrl, region, hmppsDomainEventQueue().topicName, hmppsDomainEventQueue().queueName,
             mapOf("FilterPolicy" to """{"eventType":[ "PRISONER_RELEASED", "PRISONER_RECEIVED"] }""")
           )
         }
-        .also { log.info("Queue ${hmppsQueue().queueName} has subscribed to hmpps topic ${hmppsQueue().topicName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue().queueName, hmppsAwsSqsDlqClient, hmppsQueue().dlqName) }
+        .also { log.info("Queue ${hmppsDomainEventQueue().queueName} has subscribed to hmpps topic ${hmppsDomainEventQueue().topicName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsDomainEventQueue().queueName, hmppsAwsSqsDlqClient, hmppsDomainEventQueue().dlqName) }
     }
 
   @Bean("hmppsAwsSqsDlqClient")
   fun hmppsAwsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { dlqSqsClient -> dlqSqsClient.createQueue(hmppsQueue().dlqName) }
-        .also { log.info("Created localstack dlq sqs client for dlq ${hmppsQueue().dlqName}") }
+        .also { dlqSqsClient -> dlqSqsClient.createQueue(hmppsDomainEventQueue().dlqName) }
+        .also { log.info("Created localstack dlq sqs client for dlq ${hmppsDomainEventQueue().dlqName}") }
     }
 
   private fun subscribeToTopic(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/LocalstackSqsConfig.kt
@@ -27,8 +27,8 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   fun awsSnsClient(sqsConfigProperties: SqsConfigProperties): AmazonSNS =
     with(sqsConfigProperties) {
       localstackAmazonSNS(localstackUrl, region)
-        .also { snsClient -> snsClient.createTopic(dpsQueue.topicName) }
-        .also { log.info("Created localstack sns topic with name ${dpsQueue.topicName}") }
+        .also { snsClient -> snsClient.createTopic(dpsQueue().topicName) }
+        .also { log.info("Created localstack sns topic with name ${dpsQueue().topicName}") }
     }
 
   @Bean("awsSqsClient")
@@ -39,32 +39,32 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   ): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { sqsClient -> createMainQueue(sqsClient, awsSqsDlqClient, dpsQueue.queueName, dpsQueue.dlqName) }
-        .also { log.info("Created localstack sqs client for queue ${dpsQueue.queueName}") }
+        .also { sqsClient -> createMainQueue(sqsClient, awsSqsDlqClient, dpsQueue().queueName, dpsQueue().dlqName) }
+        .also { log.info("Created localstack sqs client for queue ${dpsQueue().queueName}") }
         .also {
           subscribeToTopic(
-            awsSnsClient, localstackUrl, region, dpsQueue.topicName, dpsQueue.queueName,
+            awsSnsClient, localstackUrl, region, dpsQueue().topicName, dpsQueue().queueName,
             mapOf("FilterPolicy" to """{"eventType":[ "EXTERNAL_MOVEMENT_RECORD-INSERTED", "IMPRISONMENT_STATUS-CHANGED", "SENTENCE_DATES-CHANGED", "BOOKING_NUMBER-CHANGED"] }""")
           )
         }
-        .also { log.info("Queue ${dpsQueue.queueName} has subscribed to dps topic ${dpsQueue.topicName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue.queueName, awsSqsDlqClient, dpsQueue.dlqName) }
+        .also { log.info("Queue ${dpsQueue().queueName} has subscribed to dps topic ${dpsQueue().topicName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, dpsQueue().queueName, awsSqsDlqClient, dpsQueue().dlqName) }
     }
 
   @Bean("awsSqsDlqClient")
   fun awsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { dlqSqsClient -> dlqSqsClient.createQueue(dpsQueue.dlqName) }
-        .also { log.info("Created localstack dlq sqs client for dlq ${dpsQueue.dlqName}") }
+        .also { dlqSqsClient -> dlqSqsClient.createQueue(dpsQueue().dlqName) }
+        .also { log.info("Created localstack dlq sqs client for dlq ${dpsQueue().dlqName}") }
     }
 
   @Bean
   fun hmppsAwsSnsClient(sqsConfigProperties: SqsConfigProperties): AmazonSNS =
     with(sqsConfigProperties) {
       localstackAmazonSNS(sqsConfigProperties.localstackUrl, sqsConfigProperties.region)
-        .also { snsClient -> snsClient.createTopic(hmppsQueue.topicName) }
-        .also { log.info("Created localstack sns topic with name ${hmppsQueue.topicName}") }
+        .also { snsClient -> snsClient.createTopic(hmppsQueue().topicName) }
+        .also { log.info("Created localstack sns topic with name ${hmppsQueue().topicName}") }
     }
 
   @Bean("hmppsAwsSqsClient")
@@ -75,24 +75,24 @@ class LocalstackSqsConfig(private val hmppsQueueService: HmppsQueueService) {
   ): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { sqsClient -> createMainQueue(sqsClient, hmppsAwsSqsDlqClient, hmppsQueue.queueName, hmppsQueue.dlqName) }
-        .also { log.info("Created localstack sqs client for queue ${hmppsQueue.queueName}") }
+        .also { sqsClient -> createMainQueue(sqsClient, hmppsAwsSqsDlqClient, hmppsQueue().queueName, hmppsQueue().dlqName) }
+        .also { log.info("Created localstack sqs client for queue ${hmppsQueue().queueName}") }
         .also {
           subscribeToTopic(
-            hmppsAwsSnsClient, localstackUrl, region, hmppsQueue.topicName, hmppsQueue.queueName,
+            hmppsAwsSnsClient, localstackUrl, region, hmppsQueue().topicName, hmppsQueue().queueName,
             mapOf("FilterPolicy" to """{"eventType":[ "PRISONER_RELEASED", "PRISONER_RECEIVED"] }""")
           )
         }
-        .also { log.info("Queue ${hmppsQueue.queueName} has subscribed to hmpps topic ${hmppsQueue.topicName}") }
-        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue.queueName, hmppsAwsSqsDlqClient, hmppsQueue.dlqName) }
+        .also { log.info("Queue ${hmppsQueue().queueName} has subscribed to hmpps topic ${hmppsQueue().topicName}") }
+        .also { hmppsQueueService.registerHmppsQueue(it, hmppsQueue().queueName, hmppsAwsSqsDlqClient, hmppsQueue().dlqName) }
     }
 
   @Bean("hmppsAwsSqsDlqClient")
   fun hmppsAwsSqsDlqClient(sqsConfigProperties: SqsConfigProperties): AmazonSQS =
     with(sqsConfigProperties) {
       localstackAmazonSQS(localstackUrl, region)
-        .also { dlqSqsClient -> dlqSqsClient.createQueue(hmppsQueue.dlqName) }
-        .also { log.info("Created localstack dlq sqs client for dlq ${hmppsQueue.dlqName}") }
+        .also { dlqSqsClient -> dlqSqsClient.createQueue(hmppsQueue().dlqName) }
+        .also { log.info("Created localstack dlq sqs client for dlq ${hmppsQueue().dlqName}") }
     }
 
   private fun subscribeToTopic(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/SqsConfigProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/SqsConfigProperties.kt
@@ -9,8 +9,7 @@ data class SqsConfigProperties(
   val region: String,
   val provider: String,
   val localstackUrl: String = "",
-  val dpsQueue: QueueConfig,
-  val hmppsQueue: QueueConfig,
+  val queues: Map<String, QueueConfig>,
 ) {
   data class QueueConfig(
     val topicName: String = "",
@@ -22,3 +21,7 @@ data class SqsConfigProperties(
     val dlqSecretAccessKey: String = "",
   )
 }
+
+fun SqsConfigProperties.dpsQueue() = queues["dpsQueue"] ?: throw MissingQueueException("dpsQueue has not been loaded from configuration properties")
+fun SqsConfigProperties.hmppsQueue() = queues["hmppsQueue"] ?: throw MissingQueueException("hmppsQueue has not been loaded from configuration properties")
+class MissingQueueException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/SqsConfigProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/config/SqsConfigProperties.kt
@@ -22,6 +22,6 @@ data class SqsConfigProperties(
   )
 }
 
-fun SqsConfigProperties.dpsQueue() = queues["dpsQueue"] ?: throw MissingQueueException("dpsQueue has not been loaded from configuration properties")
-fun SqsConfigProperties.hmppsQueue() = queues["hmppsQueue"] ?: throw MissingQueueException("hmppsQueue has not been loaded from configuration properties")
+fun SqsConfigProperties.prisonEventQueue() = queues["prisonEventQueue"] ?: throw MissingQueueException("prisonEventQueue has not been loaded from configuration properties")
+fun SqsConfigProperties.hmppsDomainEventQueue() = queues["hmppsDomainEventQueue"] ?: throw MissingQueueException("hmppsDomainEventQueue has not been loaded from configuration properties")
 class MissingQueueException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/HMPPSPrisonerChangesListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/HMPPSPrisonerChangesListenerPusher.kt
@@ -18,10 +18,7 @@ class HMPPSPrisonerChangesListenerPusher(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @JmsListener(
-    destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.hmppsQueue.queueName}",
-    containerFactory = "hmppsJmsListenerContainerFactory"
-  )
+  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['hmppsQueue'].queueName}", containerFactory = "hmppsJmsListenerContainerFactory")
   fun pushHMPPSPrisonUpdateToProbation(requestJson: String?) {
     log.debug(requestJson)
     val (message, messageId, messageAttributes) = objectMapper.readValue(requestJson, HMPPSMessage::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/HMPPSPrisonerChangesListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/HMPPSPrisonerChangesListenerPusher.kt
@@ -18,7 +18,7 @@ class HMPPSPrisonerChangesListenerPusher(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['hmppsQueue'].queueName}", containerFactory = "hmppsJmsListenerContainerFactory")
+  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['hmppsDomainEventQueue'].queueName}", containerFactory = "hmppsJmsListenerContainerFactory")
   fun pushHMPPSPrisonUpdateToProbation(requestJson: String?) {
     log.debug(requestJson)
     val (message, messageId, messageAttributes) = objectMapper.readValue(requestJson, HMPPSMessage::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
@@ -20,7 +20,7 @@ class PrisonerChangesListenerPusher(
     val gson: Gson = GsonBuilder().create()
   }
 
-  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.dpsQueue.queueName}", containerFactory = "jmsListenerContainerFactory")
+  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.dpsQueue().queueName}", containerFactory = "jmsListenerContainerFactory")
   fun pushPrisonUpdateToProbation(requestJson: String?) {
     log.debug(requestJson)
     val (message, messageId, messageAttributes) = gson.fromJson(requestJson, Message::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
@@ -20,7 +20,7 @@ class PrisonerChangesListenerPusher(
     val gson: Gson = GsonBuilder().create()
   }
 
-  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['dpsQueue'].queueName}", containerFactory = "jmsListenerContainerFactory")
+  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['prisonEventQueue'].queueName}", containerFactory = "jmsListenerContainerFactory")
   fun pushPrisonUpdateToProbation(requestJson: String?) {
     log.debug(requestJson)
     val (message, messageId, messageAttributes) = gson.fromJson(requestJson, Message::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/PrisonerChangesListenerPusher.kt
@@ -20,7 +20,7 @@ class PrisonerChangesListenerPusher(
     val gson: Gson = GsonBuilder().create()
   }
 
-  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.dpsQueue().queueName}", containerFactory = "jmsListenerContainerFactory")
+  @JmsListener(destination = "#{@'hmpps.sqs-uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties'.queues['dpsQueue'].queueName}", containerFactory = "jmsListenerContainerFactory")
   fun pushPrisonUpdateToProbation(requestJson: String?) {
     log.debug(requestJson)
     val (message, messageId, messageAttributes) = gson.fromJson(requestJson, Message::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/health/QueueHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/health/QueueHealth.kt
@@ -17,6 +17,8 @@ import org.springframework.boot.actuate.health.Health.Builder
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_ATTACHED
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_AVAILABLE
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_FOUND
@@ -98,11 +100,11 @@ class PrisonEventsQueueHealth(
   @Autowired @Qualifier("awsSqsClient") awsSqsClient: AmazonSQS,
   @Autowired @Qualifier("awsSqsDlqClient") awsSqsDlqClient: AmazonSQS,
   sqsConfigProperties: SqsConfigProperties,
-) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.dpsQueue.queueName, sqsConfigProperties.dpsQueue.dlqName)
+) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.dpsQueue().queueName, sqsConfigProperties.dpsQueue().dlqName)
 
 @Component
 class HMPPSEventsQueueHealth(
   @Autowired @Qualifier("hmppsAwsSqsClient") awsSqsClient: AmazonSQS,
   @Autowired @Qualifier("hmppsAwsSqsDlqClient") awsSqsDlqClient: AmazonSQS,
   sqsConfigProperties: SqsConfigProperties,
-) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.hmppsQueue.queueName, sqsConfigProperties.hmppsQueue.dlqName)
+) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.hmppsQueue().queueName, sqsConfigProperties.hmppsQueue().dlqName)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/health/QueueHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/services/health/QueueHealth.kt
@@ -17,8 +17,8 @@ import org.springframework.boot.actuate.health.Health.Builder
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties
-import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
-import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsDomainEventQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.prisonEventQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_ATTACHED
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_AVAILABLE
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.health.DlqStatus.NOT_FOUND
@@ -100,11 +100,11 @@ class PrisonEventsQueueHealth(
   @Autowired @Qualifier("awsSqsClient") awsSqsClient: AmazonSQS,
   @Autowired @Qualifier("awsSqsDlqClient") awsSqsDlqClient: AmazonSQS,
   sqsConfigProperties: SqsConfigProperties,
-) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.dpsQueue().queueName, sqsConfigProperties.dpsQueue().dlqName)
+) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.prisonEventQueue().queueName, sqsConfigProperties.prisonEventQueue().dlqName)
 
 @Component
 class HMPPSEventsQueueHealth(
   @Autowired @Qualifier("hmppsAwsSqsClient") awsSqsClient: AmazonSQS,
   @Autowired @Qualifier("hmppsAwsSqsDlqClient") awsSqsDlqClient: AmazonSQS,
   sqsConfigProperties: SqsConfigProperties,
-) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.hmppsQueue().queueName, sqsConfigProperties.hmppsQueue().dlqName)
+) : QueueHealth(awsSqsClient, awsSqsDlqClient, sqsConfigProperties.hmppsDomainEventQueue().queueName, sqsConfigProperties.hmppsDomainEventQueue().dlqName)

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -5,11 +5,11 @@ hmpps.sqs:
   provider: ${aws.provider}
   localstackUrl: http://localhost:4566
   queues:
-    dpsQueue:
+    prisonEventQueue:
       topicName: dps-topic
       queueName: dps-queue
       dlqName: dps-dlq
-    hmppsQueue:
+    hmppsDomainEventQueue:
       topicName: hmpps-topic
       queueName: hmpps-queue
       dlqName: hmpps-dlq

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -4,14 +4,15 @@ graceful:
 hmpps.sqs:
   provider: ${aws.provider}
   localstackUrl: http://localhost:4566
-  dpsQueue:
-    topicName: dps-topic
-    queueName: dps-queue
-    dlqName: dps-dlq
-  hmppsQueue:
-    topicName: hmpps-topic
-    queueName: hmpps-queue
-    dlqName: hmpps-dlq
+  queues:
+    dpsQueue:
+      topicName: dps-topic
+      queueName: dps-queue
+      dlqName: dps-dlq
+    hmppsQueue:
+      topicName: hmpps-topic
+      queueName: hmpps-queue
+      dlqName: hmpps-dlq
 
 hmpps.dynamodb:
   provider: ${aws.provider}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,20 +111,21 @@ hmpps.sqs:
   provider: ${aws.provider}
   region: ${aws.region}
   queueAdminRole: ROLE_PTPU_QUEUE_ADMIN
-  dpsQueue:
-    queueName: ${sqs.queue.name}
-    queueAccessKeyId: ${sqs.aws.access.key.id}
-    queueSecretAccessKey: ${sqs.aws.secret.access.key}
-    dlqName: ${sqs.dlq.name}
-    dlqAccessKeyId: ${sqs.aws.dlq.access.key.id}
-    dlqSecretAccessKey: ${sqs.aws.dlq.secret.access.key}
-  hmppsQueue:
-    queueName: ${sqs.hmpps.queue.name}
-    queueAccessKeyId: ${sqs.hmpps.aws.access.key.id}
-    queueSecretAccessKey: ${sqs.hmpps.aws.secret.access.key}
-    dlqName: ${sqs.hmpps.dlq.name}
-    dlqAccessKeyId: ${sqs.hmpps.aws.dlq.access.key.id}
-    dlqSecretAccessKey: ${sqs.hmpps.aws.dlq.secret.access.key}
+  queues:
+    dpsQueue:
+      queueName: ${sqs.queue.name}
+      queueAccessKeyId: ${sqs.aws.access.key.id}
+      queueSecretAccessKey: ${sqs.aws.secret.access.key}
+      dlqName: ${sqs.dlq.name}
+      dlqAccessKeyId: ${sqs.aws.dlq.access.key.id}
+      dlqSecretAccessKey: ${sqs.aws.dlq.secret.access.key}
+    hmppsQueue:
+      queueName: ${sqs.hmpps.queue.name}
+      queueAccessKeyId: ${sqs.hmpps.aws.access.key.id}
+      queueSecretAccessKey: ${sqs.hmpps.aws.secret.access.key}
+      dlqName: ${sqs.hmpps.dlq.name}
+      dlqAccessKeyId: ${sqs.hmpps.aws.dlq.access.key.id}
+      dlqSecretAccessKey: ${sqs.hmpps.aws.dlq.secret.access.key}
 
 hmpps.dynamodb:
   region: ${aws.region}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,14 +112,14 @@ hmpps.sqs:
   region: ${aws.region}
   queueAdminRole: ROLE_PTPU_QUEUE_ADMIN
   queues:
-    dpsQueue:
+    prisonEventQueue:
       queueName: ${sqs.queue.name}
       queueAccessKeyId: ${sqs.aws.access.key.id}
       queueSecretAccessKey: ${sqs.aws.secret.access.key}
       dlqName: ${sqs.dlq.name}
       dlqAccessKeyId: ${sqs.aws.dlq.access.key.id}
       dlqSecretAccessKey: ${sqs.aws.dlq.secret.access.key}
-    hmppsQueue:
+    hmppsDomainEventQueue:
       queueName: ${sqs.hmpps.queue.name}
       queueAccessKeyId: ${sqs.hmpps.aws.access.key.id}
       queueSecretAccessKey: ${sqs.hmpps.aws.secret.access.key}

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/IntegrationTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/IntegrationTest.kt
@@ -24,8 +24,8 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties
-import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
-import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsDomainEventQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.prisonEventQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.helper.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisontoprobation.repositories.MessageRepository
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.MessageProcessor
@@ -48,13 +48,13 @@ abstract class IntegrationTest {
   @Qualifier("awsSqsClient")
   protected lateinit var awsSqsClient: AmazonSQS
 
-  internal val queueName: String by lazy { sqsConfigProperties.dpsQueue().queueName }
+  internal val queueName: String by lazy { sqsConfigProperties.prisonEventQueue().queueName }
 
   @SpyBean
   @Qualifier("hmppsAwsSqsClient")
   protected lateinit var hmppsAwsSqsClient: AmazonSQS
 
-  internal val hmppsQueueName: String by lazy { sqsConfigProperties.hmppsQueue().queueName }
+  internal val hmppsQueueName: String by lazy { sqsConfigProperties.hmppsDomainEventQueue().queueName }
 
   @SpyBean
   @Qualifier("awsSqsDlqClient")
@@ -64,9 +64,9 @@ abstract class IntegrationTest {
   @Qualifier("hmppsAwsSqsDlqClient")
   internal lateinit var hmppsAwsSqsDlqClient: AmazonSQS
 
-  internal val dlqName: String by lazy { sqsConfigProperties.dpsQueue().dlqName }
+  internal val dlqName: String by lazy { sqsConfigProperties.prisonEventQueue().dlqName }
 
-  internal val hmppsDlqName: String by lazy { sqsConfigProperties.hmppsQueue().dlqName }
+  internal val hmppsDlqName: String by lazy { sqsConfigProperties.hmppsDomainEventQueue().dlqName }
 
   @SpyBean
   internal lateinit var messageProcessor: MessageProcessor

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/IntegrationTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/IntegrationTest.kt
@@ -24,6 +24,8 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisontoprobation.config.SqsConfigProperties
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.hmppsQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.helper.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisontoprobation.repositories.MessageRepository
 import uk.gov.justice.digital.hmpps.prisontoprobation.services.MessageProcessor
@@ -46,13 +48,13 @@ abstract class IntegrationTest {
   @Qualifier("awsSqsClient")
   protected lateinit var awsSqsClient: AmazonSQS
 
-  internal val queueName: String by lazy { sqsConfigProperties.dpsQueue.queueName }
+  internal val queueName: String by lazy { sqsConfigProperties.dpsQueue().queueName }
 
   @SpyBean
   @Qualifier("hmppsAwsSqsClient")
   protected lateinit var hmppsAwsSqsClient: AmazonSQS
 
-  internal val hmppsQueueName: String by lazy { sqsConfigProperties.hmppsQueue.queueName }
+  internal val hmppsQueueName: String by lazy { sqsConfigProperties.hmppsQueue().queueName }
 
   @SpyBean
   @Qualifier("awsSqsDlqClient")
@@ -62,9 +64,9 @@ abstract class IntegrationTest {
   @Qualifier("hmppsAwsSqsDlqClient")
   internal lateinit var hmppsAwsSqsDlqClient: AmazonSQS
 
-  internal val dlqName: String by lazy { sqsConfigProperties.dpsQueue.dlqName }
+  internal val dlqName: String by lazy { sqsConfigProperties.dpsQueue().dlqName }
 
-  internal val hmppsDlqName: String by lazy { sqsConfigProperties.hmppsQueue.dlqName }
+  internal val hmppsDlqName: String by lazy { sqsConfigProperties.hmppsQueue().dlqName }
 
   @SpyBean
   internal lateinit var messageProcessor: MessageProcessor

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/e2e/HouseKeepingIntegrationTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/e2e/HouseKeepingIntegrationTest.kt
@@ -8,7 +8,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.prisonEventQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.entity.Message
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -44,7 +44,7 @@ class HouseKeepingIntegrationTest : QueueListenerIntegrationTest() {
     awsSqsClient.sendMessage(dlqUrl, "{}")
 
     webTestClient.put()
-      .uri("/queue-admin/purge-queue/${sqsConfigProperties.dpsQueue().dlqName}")
+      .uri("/queue-admin/purge-queue/${sqsConfigProperties.prisonEventQueue().dlqName}")
       .headers(setAuthorisation(roles = listOf("ROLE_PTPU_QUEUE_ADMIN")))
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -66,7 +66,7 @@ class HouseKeepingIntegrationTest : QueueListenerIntegrationTest() {
     awsSqsClient.sendMessage(dlqUrl, message)
 
     webTestClient.put()
-      .uri("/queue-admin/retry-dlq/${sqsConfigProperties.dpsQueue().dlqName}")
+      .uri("/queue-admin/retry-dlq/${sqsConfigProperties.prisonEventQueue().dlqName}")
       .headers(setAuthorisation(roles = listOf("ROLE_PTPU_QUEUE_ADMIN")))
       .accept(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/e2e/HouseKeepingIntegrationTest.kt
+++ b/src/testIntegration/kotlin/uk/gov/justice/digital/hmpps/prisontoprobation/e2e/HouseKeepingIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.prisontoprobation.config.dpsQueue
 import uk.gov.justice.digital.hmpps.prisontoprobation.entity.Message
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -43,7 +44,7 @@ class HouseKeepingIntegrationTest : QueueListenerIntegrationTest() {
     awsSqsClient.sendMessage(dlqUrl, "{}")
 
     webTestClient.put()
-      .uri("/queue-admin/purge-queue/${sqsConfigProperties.dpsQueue.dlqName}")
+      .uri("/queue-admin/purge-queue/${sqsConfigProperties.dpsQueue().dlqName}")
       .headers(setAuthorisation(roles = listOf("ROLE_PTPU_QUEUE_ADMIN")))
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -65,7 +66,7 @@ class HouseKeepingIntegrationTest : QueueListenerIntegrationTest() {
     awsSqsClient.sendMessage(dlqUrl, message)
 
     webTestClient.put()
-      .uri("/queue-admin/retry-dlq/${sqsConfigProperties.dpsQueue.dlqName}")
+      .uri("/queue-admin/retry-dlq/${sqsConfigProperties.dpsQueue().dlqName}")
       .headers(setAuthorisation(roles = listOf("ROLE_PTPU_QUEUE_ADMIN")))
       .accept(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/testIntegration/resources/application-test.yml
+++ b/src/testIntegration/resources/application-test.yml
@@ -9,14 +9,15 @@ aws:
 hmpps.sqs:
   provider: ${aws.provider}
   localstackUrl: http://localhost:4566
-  dpsQueue:
-    topicName: ${random.uuid}
-    queueName: ${random.uuid}
-    dlqName: ${random.uuid}
-  hmppsQueue:
-    topicName: ${random.uuid}
-    queueName: ${random.uuid}
-    dlqName: ${random.uuid}
+  queues:
+    dpsQueue:
+      topicName: ${random.uuid}
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
+    hmppsQueue:
+      topicName: ${random.uuid}
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
 
 hmpps.dynamodb:
   provider: ${aws.provider}

--- a/src/testIntegration/resources/application-test.yml
+++ b/src/testIntegration/resources/application-test.yml
@@ -10,11 +10,11 @@ hmpps.sqs:
   provider: ${aws.provider}
   localstackUrl: http://localhost:4566
   queues:
-    dpsQueue:
+    prisonEventQueue:
       topicName: ${random.uuid}
       queueName: ${random.uuid}
       dlqName: ${random.uuid}
-    hmppsQueue:
+    hmppsDomainEventQueue:
       topicName: ${random.uuid}
       queueName: ${random.uuid}
       dlqName: ${random.uuid}


### PR DESCRIPTION
Includes an experiment for a more generic configuration properties - with one eye on moving `hmpps.sqs` properties into the queue lib in the future.