### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/prison-to-probation-update/values.yaml
+++ b/helm_deploy/prison-to-probation-update/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 generic-service:
   nameOverride: prison-to-probation-update
@@ -10,7 +9,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/prison-to-probation-update
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -54,8 +53,8 @@ generic-service:
       DYNAMODB_SCHEDULE_TABLENAME: "table_name"
 
   allowlist:
-    groups:
-      - internal
+    undefined: internal/32
+    groups: []
 
 generic-prometheus-alerts:
   targetApplication: prison-to-probation-update


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/prison-to-probation-update/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `1 => 1 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
